### PR TITLE
Fix endless loop for big packages in RawSocketTransport

### DIFF
--- a/src/Thruway/Transport/RawSocketTransport.php
+++ b/src/Thruway/Transport/RawSocketTransport.php
@@ -99,7 +99,7 @@ class RawSocketTransport implements TransportInterface
 
         $bufferLen = strlen($this->buffer);
 
-        while ($bufferLen > 0) {
+        while ($bufferLen > 0 && $bufferLen >= $this->msgLen) {
             if ($this->msgLen == 0) {
                 // the next 4 bytes are going to be the msglen
                 if ($bufferLen >= 4) {


### PR DESCRIPTION
When the raw socket transport receives packages greater than the buffer size (4096) of the React Stream, handleData() will only receive the first 4096 bytes initially and be sent into an endless loop because it assumes it always has the full package after it read the size of the package.
