### PR TITLE
Update WampCraAuthProvider.php

### DIFF
--- a/src/Thruway/Authentication/WampCraAuthProvider.php
+++ b/src/Thruway/Authentication/WampCraAuthProvider.php
@@ -43,8 +43,8 @@ class WampCraAuthProvider extends AbstractAuthProviderClient
             $helloMsg = $args[0];
 
             $authid = "";
-            if (isset($helloMsg->getDetails()['authid'])) {
-                $authid = $helloMsg->getDetails()['authid'];
+            if (isset($helloMsg->getDetails()->authid)) {
+                $authid = $helloMsg->getDetails()->authid;
             } else {
                 return ["ERROR"];
             }


### PR DESCRIPTION
Bugfix: PHP Fatal error: Cannot use object of type stdClass as array in WampCraAuthProvider.php on line 46
