### PR TITLE
Fixed adding roles after authorization

### DIFF
--- a/src/Thruway/Role/Broker.php
+++ b/src/Thruway/Role/Broker.php
@@ -68,7 +68,7 @@ class Broker implements ManageableInterface, RealmModuleInterface
           "SubscribeMessageEvent"   => ["handleSubscribeMessage", 10],
           "UnsubscribeMessageEvent" => ["handleUnsubscribeMessage", 10],
           "LeaveRealm"              => ["handleLeaveRealm", 10],
-          "SendWelcomeMessageEvent" => ["handleSendWelcomeMessage", 10]
+          "SendWelcomeMessageEvent" => ["handleSendWelcomeMessage", 20]
         ];
     }
 


### PR DESCRIPTION
Tried to use dev version with AutobahnJS and see following error when authorization manage is attached:
autobahn.js:3533 Uncaught TypeError: Cannot read property 'broker' of undefined

AFICS, this happens because SendWelcomeMessageEvent handler from \Thruway\Session works before the same event handler in \Thruway\Role\Broker

My fix was just to set higher priority for Broker handler. Please tell me if there is better way.