### PR TITLE
Fixed issue in Broker with Unsubscribes

### DIFF
--- a/src/Thruway/Role/Broker.php
+++ b/src/Thruway/Role/Broker.php
@@ -209,7 +209,11 @@ class Broker implements ManageableInterface, RealmModuleInterface
         // should probably be more efficient about this - maybe later
         /** @var SubscriptionGroup $subscriptionGroup */
         foreach ($this->subscriptionGroups as $subscriptionGroup) {
-            $subscription = $subscriptionGroup->processUnsubscribe($session, $msg);
+            $result = $subscriptionGroup->processUnsubscribe($session, $msg);
+            
+            if ($result !== false) {
+                $subscription = $result;
+            }
         }
 
         if ($subscription === false) {


### PR DESCRIPTION
I think this will fix the issue in #100 

It looks like if an unsubscribe was processed in a SubscriptionGroup and the following SubscriptionGroup  (assuming there is more than one) returned a false it would cause the Broker to return a no such subscription error, despite the unsubscribe already being processed.

I'm not 100% sure but I assume the subscription would only ever appear in one group? If so you could probably do a return here? (that might not be the case)