### PR TITLE
Added mcrypt to require composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,10 @@
         "cboden/ratchet": "0.3.*",
         "ratchet/pawl": "0.1.*",
         "psr/log": "~1",
-        "guzzle/guzzle": "~3.9",
-        "ext-mcrypt":"*"
+        "guzzle/guzzle": "~3.9"
+    },
+    "suggest": {
+	    "ext-mcrypt":"If you want to use WAMP-CRA for authentication"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "cboden/ratchet": "0.3.*",
         "ratchet/pawl": "0.1.*",
         "psr/log": "~1",
-        "guzzle/guzzle": "~3.9"
+        "guzzle/guzzle": "~3.9",
+        "ext-mcrypt":"*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Hello.
I've just tried to run tests, and got this error:

>PHP Fatal error:  Call to undefined function Thruway\Authentication\mcrypt_create_iv() in /projects/github/Thruway/src/Thruway/Authentication/WampCraAuthProvider.php on line 70

I added ext-mcrypt to composer.json