### PR TITLE
Check against PromiseInterface instead of Promise

### DIFF
--- a/src/Thruway/Role/Callee.php
+++ b/src/Thruway/Role/Callee.php
@@ -3,7 +3,7 @@
 namespace Thruway\Role;
 
 use React\Promise\Deferred;
-use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 use Thruway\AbstractSession;
 use Thruway\ClientSession;
 use Thruway\Common\Utils;
@@ -173,7 +173,7 @@ class Callee extends AbstractRole
                     try {
                         $results = $registration["callback"]($msg->getArguments(), $msg->getArgumentsKw(), $msg->getDetails());
 
-                        if ($results instanceof Promise) {
+                        if ($results instanceof PromiseInterface) {
                             $this->processResultAsPromise($results, $msg, $session, $registration);
                         } else {
                             $this->processResultAsArray($results, $msg, $session);
@@ -193,12 +193,12 @@ class Callee extends AbstractRole
     /**
      *  Process a result as a promise
      *
-     * @param \React\Promise\Promise $promise
+     * @param \React\Promise\PromiseInterface $promise
      * @param \Thruway\Message\InvocationMessage $msg
      * @param \Thruway\ClientSession $session
      * @param array $registration
      */
-    private function processResultAsPromise(Promise $promise, InvocationMessage $msg, ClientSession $session, $registration)
+    private function processResultAsPromise(PromiseInterface $promise, InvocationMessage $msg, ClientSession $session, $registration)
     {
 
         $promise->then(


### PR DESCRIPTION
Currently you can return a promise instead of a value but that is only limited to the `Promise` class like this example:

```php
$d = new \React\Promise\Deferred();

$loop->addTimer(3, function () use ($d, $args) {
    $d->resolve("it worked!!! " . $args[0]);
});

return $d->promise();
```

When using the `PromiseInterface` you can use all promises react provides + any custom ones by others, for example:

```php
return \React\Promise\resolve('abc);
```