### PR TITLE
$arguments can be instance of stdClass

### DIFF
--- a/src/Thruway/Message/Traits/ArgumentsTrait.php
+++ b/src/Thruway/Message/Traits/ArgumentsTrait.php
@@ -65,7 +65,7 @@ trait ArgumentsTrait
      */
     public function setArguments($arguments)
     {
-        if (is_array($arguments) || $arguments === null) {
+        if (is_array($arguments) || $arguments instanceof \stdClass || $arguments === null) {
             $this->arguments = $arguments;
         } else {
             $this->arguments = null;


### PR DESCRIPTION
Since https://github.com/voryx/Thruway/commit/f983bbd0ff23e40e27db2389725bb3b0017024fa#diff-00086c0b6ec1692275e81449dd400ee7L37 JSON data isn't decoded into an array anymore. The [ArgumentsTrait](https://github.com/voryx/Thruway/blob/4d26ed034b02036284a60a2efeb42a89e66f6a40/src/Thruway/Message/Traits/ArgumentsTrait.php#L68) still assumes it gets messages as an array. This PR adds a check for `stdClass` so both arrays and `stdClass` objects can pass through.