### PR TITLE
[RFC] Schedule InternalClientTransport sends to prevent deep stacks

### DIFF
--- a/src/Thruway/Transport/InternalClientTransport.php
+++ b/src/Thruway/Transport/InternalClientTransport.php
@@ -4,7 +4,6 @@ namespace Thruway\Transport;
 
 use React\EventLoop\LoopInterface;
 use Thruway\Message\Message;
-use Thruway\Peer\PeerInterface;
 
 /**
  * Class InternalClientTransport
@@ -34,7 +33,9 @@ class InternalClientTransport extends AbstractTransport
     public function sendMessage(Message $msg)
     {
         if (is_callable($this->sendMessageFunction)) {
-            call_user_func_array($this->sendMessageFunction, [$msg]);
+            $this->getLoop()->nextTick(function () use ($msg) {
+                call_user_func_array($this->sendMessageFunction, [$msg]);
+            });
         }
     }
 


### PR DESCRIPTION
This does break some tests, not sure if it would have a big impact in production.
