### PR TITLE
Adding Shared Registrations (roundrobin,random,first,last) as specified by WAMPv2

### DIFF
--- a/src/Thruway/Procedure.php
+++ b/src/Thruway/Procedure.php
@@ -17,7 +17,8 @@ use SplQueue;
  *
  * @package Thruway
  */
-class Procedure {
+class Procedure
+{
 
     /**
      * @var string
@@ -54,7 +55,8 @@ class Procedure {
      *
      * @param string $procedureName
      */
-    public function __construct($procedureName) {
+    public function __construct($procedureName)
+    {
         $this->setProcedureName($procedureName);
 
         $this->registrations = [];
@@ -73,7 +75,8 @@ class Procedure {
      * @return bool
      * @throws \Exception
      */
-    public function processRegister(Session $session, RegisterMessage $msg) {
+    public function processRegister(Session $session, RegisterMessage $msg)
+    {
         $registration = Registration::createRegistrationFromRegisterMessage($session, $msg);
 
         if (count($this->registrations) > 0) {
@@ -132,7 +135,8 @@ class Procedure {
      * @return bool
      * @throws \Exception
      */
-    private function addRegistration(Registration $registration, RegisterMessage $msg) {
+    private function addRegistration(Registration $registration, RegisterMessage $msg)
+    {
         try {
             // make sure the uri is exactly the same
             if ($registration->getProcedureName() != $this->getProcedureName()) {
@@ -170,7 +174,8 @@ class Procedure {
      * @param $registrationId
      * @return bool|Registration
      */
-    public function getRegistrationById($registrationId) {
+    public function getRegistrationById($registrationId)
+    {
         /** @var Registration $registration */
         foreach ($this->registrations as $registration) {
             if ($registration->getId() == $registrationId) {
@@ -188,7 +193,8 @@ class Procedure {
      * @param \Thruway\Message\UnregisterMessage $msg
      * @return bool
      */
-    public function processUnregister(Session $session, UnregisterMessage $msg) {
+    public function processUnregister(Session $session, UnregisterMessage $msg)
+    {
         for ($i = 0; $i < count($this->registrations); $i++) {
             /** @var Registration $registration */
             $registration = $this->registrations[$i];
@@ -223,7 +229,8 @@ class Procedure {
      * @throws \Exception
      * @return bool | Call
      */
-    public function processCall(Session $session, Call $call) {
+    public function processCall(Session $session, Call $call)
+    {
         // find a registration to call
         if (count($this->registrations) == 0) {
             $session->sendMessage(ErrorMessage::createErrorMessageFromMessage($call->getCallMessage(), 'wamp.error.no_such_procedure'));
@@ -246,7 +253,8 @@ class Procedure {
      *
      * @throws \Exception
      */
-    public function processQueue() {
+    public function processQueue()
+    {
         if (!$this->getAllowMultipleRegistrations()) {
             throw new \Exception("Queuing only allowed when there are multiple registrations");
         }
@@ -274,7 +282,8 @@ class Procedure {
         }
     }
 
-    private function getNextThruwayRegistration() {
+    private function getNextThruwayRegistration()
+    {
         $congestion = true;
         /* @var $bestRegistration \Thruway\Registration */
         $bestRegistration = $this->registrations[0];
@@ -301,12 +310,14 @@ class Procedure {
         return $bestRegistration;
     }
 
-    private function getNextRandomRegistration() {
+    private function getNextRandomRegistration()
+    {
         //mt_rand is apparently faster than array_rand(which uses the libc generator)
         return $this->registrations[mt_rand(0, count($this->registrations) - 1)];
     }
 
-    private function getNextRoundRobinRegistration() {
+    private function getNextRoundRobinRegistration()
+    {
         /* @var $bestRegistration \Thruway\Registration */
         $bestRegistration = $this->registrations[0];
         /* @var $registration \Thruway\Registration */
@@ -320,13 +331,15 @@ class Procedure {
         return $bestRegistration;
     }
 
-    private function getNextFirstRegistration() {
+    private function getNextFirstRegistration()
+    {
         /* @var $bestRegistration \Thruway\Registration */
         $bestRegistration = $this->registrations[0];
         return $bestRegistration;
     }
 
-    private function getNextLastRegistration() {
+    private function getNextLastRegistration()
+    {
         /* @var $bestRegistration \Thruway\Registration */
         $bestRegistration = $this->registrations[count($this->registrations) - 1];
         return $bestRegistration;
@@ -337,7 +350,8 @@ class Procedure {
      *
      * @param Call $call
      */
-    public function removeCall(Call $call) {
+    public function removeCall(Call $call)
+    {
         $newQueue = new \SplQueue();
         while (!$this->callQueue->isEmpty()) {
             $c = $this->callQueue->dequeue();
@@ -361,7 +375,8 @@ class Procedure {
      * @param int $requestId
      * @return \Thruway\Call|boolean
      */
-    public function getCallByRequestId($requestId) {
+    public function getCallByRequestId($requestId)
+    {
         /* @var $registration \Thruway\Registration */
         foreach ($this->registrations as $registration) {
             $call = $registration->getCallByRequestId($requestId);
@@ -376,77 +391,88 @@ class Procedure {
     /**
      * @return string
      */
-    public function getProcedureName() {
+    public function getProcedureName()
+    {
         return $this->procedureName;
     }
 
     /**
      * @param string $procedureName
      */
-    private function setProcedureName($procedureName) {
+    private function setProcedureName($procedureName)
+    {
         $this->procedureName = $procedureName;
     }
 
     /**
      * @return boolean
      */
-    public function isDiscloseCaller() {
+    public function isDiscloseCaller()
+    {
         return $this->getDiscloseCaller();
     }
 
     /**
      * @return boolean
      */
-    public function getDiscloseCaller() {
+    public function getDiscloseCaller()
+    {
         return $this->discloseCaller;
     }
 
     /**
      * @param boolean $discloseCaller
      */
-    public function setDiscloseCaller($discloseCaller) {
+    public function setDiscloseCaller($discloseCaller)
+    {
         $this->discloseCaller = $discloseCaller;
     }
 
     /**
      * @return string
      */
-    public function getInvokeType() {
+    public function getInvokeType()
+    {
         return $this->invokeType;
     }
 
     /**
      * @param string $invokeType
      */
-    public function setInvokeType($invoketype) {
+    public function setInvokeType($invoketype)
+    {
         $this->invokeType = $invoketype;
     }
 
     /**
      * @return boolean
      */
-    public function isAllowMultipleRegistrations() {
+    public function isAllowMultipleRegistrations()
+    {
         return $this->getAllowMultipleRegistrations();
     }
 
     /**
      * @return boolean
      */
-    public function getAllowMultipleRegistrations() {
+    public function getAllowMultipleRegistrations()
+    {
         return $this->allowMultipleRegistrations;
     }
 
     /**
      * @param boolean $allowMultipleRegistrations
      */
-    public function setAllowMultipleRegistrations($allowMultipleRegistrations) {
+    public function setAllowMultipleRegistrations($allowMultipleRegistrations)
+    {
         $this->allowMultipleRegistrations = $allowMultipleRegistrations;
     }
 
     /**
      * @return array
      */
-    public function getRegistrations() {
+    public function getRegistrations()
+    {
         return $this->registrations;
     }
 
@@ -455,7 +481,8 @@ class Procedure {
      *
      * @param \Thruway\Session $session
      */
-    public function leave(Session $session) {
+    public function leave(Session $session)
+    {
         // remove all registrations that belong to this session
         /* @var $registration \Thruway\Registration */
         foreach ($this->registrations as $i => $registration) {
@@ -471,7 +498,8 @@ class Procedure {
      * todo: This was part of the manager stuff - but may be used by some tests
      *
      */
-    public function managerGetRegistrations() {
+    public function managerGetRegistrations()
+    {
         $registrations = $this->getRegistrations();
 
         $regInfo = [];

--- a/src/Thruway/Procedure.php
+++ b/src/Thruway/Procedure.php
@@ -313,7 +313,7 @@ class Procedure
 
     private function getNextRandomRegistration()
     {
-        if (count($this->registrations) === 1){
+        if (count($this->registrations) === 1) {
             //just return this so that we don't have to run mt_rand
             return $this->registrations[0];
         }
@@ -332,12 +332,6 @@ class Procedure
                 $bestRegistration = $registration;
                 break;
             }
-        }
-        if ($bestRegistration->getSession()->getPendingCallCount() !== 0) {
-            //emit a congestion to let people know that we have one...
-            $bestRegistration->getSession()->getRealm()->publishMeta('thruway.metaevent.procedure.congestion', [
-                ["name" => $this->getProcedureName()]]
-            );
         }
         return $bestRegistration;
     }

--- a/src/Thruway/Procedure.php
+++ b/src/Thruway/Procedure.php
@@ -507,6 +507,7 @@ class Procedure
         foreach ($registrations as $reg) {
             $regInfo[] = [
                 'id' => $reg->getId(),
+                "invoke" => $reg->getInvokeType(),
                 "thruway_multiregister" => $reg->getAllowMultipleRegistrations(),
                 "disclose_caller" => $reg->getDiscloseCaller(),
                 "session" => $reg->getSession()->getSessionId(),

--- a/src/Thruway/Registration.php
+++ b/src/Thruway/Registration.php
@@ -149,11 +149,9 @@ class Registration
             $registration->setInvokeType($options->invoke);
         } else {
             if (isset($options->thruway_multiregister) && $options->thruway_multiregister === true) {
-                $registration->setAllowMultipleRegistrations(true);
                 $registration->setInvokeType(Registration::THRUWAY_REGISTRATION);
             } else {
                 $registration->setInvokeType(Registration::SINGLE_REGISTRATION);
-                $registration->setAllowMultipleRegistrations(false);
             }
         }
 
@@ -212,6 +210,10 @@ class Registration
             if ($type !== Registration::SINGLE_REGISTRATION) {
                 $this->invokeType = $type;
                 $this->setAllowMultipleRegistrations(true);
+            }
+            else {
+                $this->invokeType = Registration::SINGLE_REGISTRATION;
+                $this->setAllowMultipleRegistrations(false);
             }
         }
     }

--- a/src/Thruway/Registration.php
+++ b/src/Thruway/Registration.php
@@ -11,7 +11,8 @@ use Thruway\Message\RegisterMessage;
  *
  * @package Thruway
  */
-class Registration {
+class Registration
+{
 
     /**
      * @var mixed
@@ -108,7 +109,8 @@ class Registration {
      * @param \Thruway\Session $session
      * @param string $procedureName
      */
-    public function __construct(Session $session, $procedureName) {
+    public function __construct(Session $session, $procedureName)
+    {
         $this->id = Utils::getUniqueId();
         $this->session = $session;
         $this->procedureName = $procedureName;
@@ -134,7 +136,8 @@ class Registration {
      * @param \Thruway\Message\RegisterMessage $msg
      * @return \Thruway\Registration
      */
-    public static function createRegistrationFromRegisterMessage(Session $session, RegisterMessage $msg) {
+    public static function createRegistrationFromRegisterMessage(Session $session, RegisterMessage $msg)
+    {
         $registration = new Registration($session, $msg->getProcedureName());
         $options = $msg->getOptions();
 
@@ -160,21 +163,24 @@ class Registration {
     /**
      * @return boolean
      */
-    public function getAllowMultipleRegistrations() {
+    public function getAllowMultipleRegistrations()
+    {
         return $this->allowMultipleRegistrations;
     }
 
     /**
      * @return boolean
      */
-    public function isAllowMultipleRegistrations() {
+    public function isAllowMultipleRegistrations()
+    {
         return $this->getAllowMultipleRegistrations();
     }
 
     /**
      * @param boolean $allowMultipleRegistrations
      */
-    public function setAllowMultipleRegistrations($allowMultipleRegistrations) {
+    public function setAllowMultipleRegistrations($allowMultipleRegistrations)
+    {
         $this->allowMultipleRegistrations = $allowMultipleRegistrations;
     }
 
@@ -182,7 +188,8 @@ class Registration {
      * 
      * @return String
      */
-    public function getInvokeType() {
+    public function getInvokeType()
+    {
         return $this->invokeType;
     }
 
@@ -190,7 +197,8 @@ class Registration {
      * 
      * @param String $type
      */
-    public function setInvokeType($type) {
+    public function setInvokeType($type)
+    {
         $type = strtolower($type);
         $allowedRegistrations = array(
             Registration::SINGLE_REGISTRATION,
@@ -214,7 +222,8 @@ class Registration {
      * @param Call $call
      * @throws \Exception
      */
-    public function processCall(Call $call) {
+    public function processCall(Call $call)
+    {
         if ($call->getRegistration() !== null) {
             throw new \Exception("Registration already set when asked to process call");
         }
@@ -243,7 +252,8 @@ class Registration {
      * @param int $requestId
      * @return boolean
      */
-    public function getCallByRequestId($requestId) {
+    public function getCallByRequestId($requestId)
+    {
         /** @var Call $call */
         foreach ($this->calls as $call) {
             if ($call->getInvocationMessage()->getRequestId() == $requestId) {
@@ -259,7 +269,8 @@ class Registration {
      *
      * @param \Thruway\Call $callToRemove
      */
-    public function removeCall($callToRemove) {
+    public function removeCall($callToRemove)
+    {
         /* @var $call \Thruway\Call */
         foreach ($this->calls as $i => $call) {
             if ($callToRemove === $call) {
@@ -291,7 +302,8 @@ class Registration {
      *
      * @return mixed
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -300,7 +312,8 @@ class Registration {
      *
      * @return string
      */
-    public function getProcedureName() {
+    public function getProcedureName()
+    {
         return $this->procedureName;
     }
 
@@ -309,7 +322,8 @@ class Registration {
      *
      * @return \Thruway\Session
      */
-    public function getSession() {
+    public function getSession()
+    {
         return $this->session;
     }
 
@@ -318,7 +332,8 @@ class Registration {
      *
      * @return mixed
      */
-    public function getDiscloseCaller() {
+    public function getDiscloseCaller()
+    {
         return $this->discloseCaller;
     }
 
@@ -327,7 +342,8 @@ class Registration {
      *
      * @param mixed $discloseCaller
      */
-    public function setDiscloseCaller($discloseCaller) {
+    public function setDiscloseCaller($discloseCaller)
+    {
         $this->discloseCaller = $discloseCaller;
     }
 
@@ -336,7 +352,8 @@ class Registration {
      *
      * @return int
      */
-    public function getCurrentCallCount() {
+    public function getCurrentCallCount()
+    {
         return count($this->calls);
     }
 
@@ -344,7 +361,8 @@ class Registration {
      * This will send error messages on all pending calls
      * This is used when a session disconnects before completing a call
      */
-    public function errorAllPendingCalls() {
+    public function errorAllPendingCalls()
+    {
         foreach ($this->calls as $call) {
             $call->getCallerSession()->sendMessage(ErrorMessage::createErrorMessageFromMessage($call->getCallMessage(), 'wamp.error.canceled'));
         }
@@ -355,7 +373,8 @@ class Registration {
      *
      * @return array
      */
-    public function getStatistics() {
+    public function getStatistics()
+    {
         return [
             'currentCallCount' => count($this->calls),
             'registeredAt' => $this->registeredAt,

--- a/tests/Unit/ProcedureTest.php
+++ b/tests/Unit/ProcedureTest.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../bootstrap.php';
 
-
 class ProcedureTest extends PHPUnit_Framework_TestCase
 {
+
     /**
      * @var \Thruway\Procedure
      */
@@ -19,29 +19,26 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     {
         $this->_proc = new \Thruway\Procedure("test_procedure");
         //$this->_session = new \Thruway\Session(new \Thruway\Transport\DummyTransport());
-
     }
 
     public function testProcessRegisterWithNameMismatch()
     {
         $this->_session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'different_name'
+                \Thruway\Common\Utils::getUniqueId(), [], 'different_name'
         );
 
         $this->_session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->callback(function ($msg) use ($registerMsg) {
-                $this->assertInstanceOf('\Thruway\Message\ErrorMessage', $msg);
-                $this->assertEquals($registerMsg->getRequestId(), $msg->getErrorRequestId());
-                $this->assertEquals($registerMsg->getMsgCode(), $msg->getErrorMsgCode());
-                return true;
-            }));
+                ->method("sendMessage")
+                ->with($this->callback(function ($msg) use ($registerMsg) {
+                            $this->assertInstanceOf('\Thruway\Message\ErrorMessage', $msg);
+                            $this->assertEquals($registerMsg->getRequestId(), $msg->getErrorRequestId());
+                            $this->assertEquals($registerMsg->getMsgCode(), $msg->getErrorMsgCode());
+                            return true;
+                        }));
 
         $this->_proc->processRegister($this->_session, $registerMsg);
 
@@ -51,18 +48,16 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testProcessRegister()
     {
         $this->_session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [], 'test_procedure'
         );
 
         $this->_session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $this->_proc->processRegister($this->_session, $registerMsg);
 
@@ -72,28 +67,26 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testDuplicateRegistration()
     {
         $this->_session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $session2 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $this->_session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [], 'test_procedure'
         );
 
         $this->_proc->processRegister($this->_session, $registerMsg);
 
         $session2->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\ErrorMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\ErrorMessage'));
 
         $this->_proc->processRegister($session2, $registerMsg);
 
@@ -103,32 +96,30 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testDuplicateRegistrationWithReplaceOrphanNoPingSupport()
     {
         $this->_session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $session2 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $this->_session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            ['replace_orphaned_session' => true],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), ['replace_orphaned_session' => true], 'test_procedure'
         );
 
         $this->_proc->processRegister($this->_session, $registerMsg);
 
         $session2->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\ErrorMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\ErrorMessage'));
 
         $this->_session->expects($this->any())
-            ->method("ping")
-            ->will($this->throwException(new \Thruway\Exception\PingNotSupportedException()));
+                ->method("ping")
+                ->will($this->throwException(new \Thruway\Exception\PingNotSupportedException()));
 
         $this->_proc->processRegister($session2, $registerMsg);
 
@@ -138,32 +129,30 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testDuplicateRegistrationWithReplaceOrphanWithPingSupportNoTimeout()
     {
         $this->_session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $session2 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $this->_session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            ['replace_orphaned_session' => true],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), ['replace_orphaned_session' => true], 'test_procedure'
         );
 
         $this->_proc->processRegister($this->_session, $registerMsg);
 
         $session2->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\ErrorMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\ErrorMessage'));
 
         $this->_session->expects($this->any())
-            ->method("ping")
-            ->will($this->returnValue(new \React\Promise\FulfilledPromise()));
+                ->method("ping")
+                ->will($this->returnValue(new \React\Promise\FulfilledPromise()));
 
         $this->_proc->processRegister($session2, $registerMsg);
 
@@ -173,36 +162,34 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testDuplicateRegistrationWithReplaceOrphanWithPingSupportTimeout()
     {
         $this->_session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $session2 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $this->_session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $this->_session->expects($this->once())
-            ->method('shutdown');
+                ->method('shutdown');
 
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            ['replace_orphaned_session' => true],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), ['replace_orphaned_session' => true], 'test_procedure'
         );
 
         $this->_proc->processRegister($this->_session, $registerMsg);
 
         $session2->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $this->_session->expects($this->once())
-            ->method("ping")
-            ->will($this->returnValue(new \React\Promise\RejectedPromise()));
+                ->method("ping")
+                ->will($this->returnValue(new \React\Promise\RejectedPromise()));
 
         $this->_proc->processRegister($session2, $registerMsg);
 
@@ -212,56 +199,50 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testMultipleRegistrations()
     {
         $realm = $this->getMockBuilder('\Thruway\Realm')
-            ->setConstructorArgs(["realm1"])
-            ->setMethods(["publishMeta"])
-            ->getMock();
+                ->setConstructorArgs(["realm1"])
+                ->setMethods(["publishMeta"])
+                ->getMock();
 
         $realm->expects($this->exactly(4))
-            ->method('publishMeta')
-            ->with(
-                $this->equalTo('thruway.metaevent.procedure.congestion'),
-                $this->equalTo([["name" => $this->_proc->getProcedureName()]])
-            );
+                ->method('publishMeta')
+                ->with(
+                        $this->equalTo('thruway.metaevent.procedure.congestion'), $this->equalTo([["name" => $this->_proc->getProcedureName()]])
+        );
 
         // create 5 sessions
-        $s                 = [];
+        $s = [];
         $currentCallCounts = [];
         $invocationToYield = null;
         for ($i = 0; $i < 5; $i++) {
             $s[$i] = $this->getMockBuilder('\Thruway\Session')
-                ->disableOriginalConstructor()
-                ->setMethods(['sendMessage', 'getRealm'])
-                ->getMock();
+                    ->disableOriginalConstructor()
+                    ->setMethods(['sendMessage', 'getRealm'])
+                    ->getMock();
 
             if ($i < 2) {
                 // TODO: without queuing
                 //$s[$i]->expects($this->exactly(3))
                 $s[$i]->expects($this->exactly(2))
-                    ->method("sendMessage")
-                    ->withConsecutive(
-                        [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')],
-                        [$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
-                    //,[$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
-                    );
+                        ->method("sendMessage")
+                        ->withConsecutive(
+                                [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')], [$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
+                                //,[$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
+                );
             } else {
                 if ($i == 2) {
                     // TODO: without queuing
                     //$s[$i]->expects($this->exactly(4))
                     $s[$i]->expects($this->exactly(3))
-                        ->method("sendMessage")
-                        ->withConsecutive(
-                            [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')],
-                            [$this->isInstanceOf('\Thruway\Message\InvocationMessage')],
-                            [$this->isInstanceOf('\Thruway\Message\InvocationMessage')],
-                            [$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
-                        );
+                            ->method("sendMessage")
+                            ->withConsecutive(
+                                    [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')], [$this->isInstanceOf('\Thruway\Message\InvocationMessage')], [$this->isInstanceOf('\Thruway\Message\InvocationMessage')], [$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
+                    );
                 } else {
                     $s[$i]->expects($this->exactly(2))
-                        ->method("sendMessage")
-                        ->withConsecutive(
-                            [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')],
-                            [$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
-                        );
+                            ->method("sendMessage")
+                            ->withConsecutive(
+                                    [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')], [$this->isInstanceOf('\Thruway\Message\InvocationMessage')]
+                    );
                 }
             }
 
@@ -272,9 +253,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         }
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            ['thruway_multiregister' => true],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), ['thruway_multiregister' => true], 'test_procedure'
         );
 
         foreach ($s as $i => $session) {
@@ -282,9 +261,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         }
 
         $callMsg = new \Thruway\Message\CallMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [], 'test_procedure'
         );
 
         // call the proc enough to get a backlog
@@ -304,8 +281,6 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $s[2]->decPendingCallCount();
 
         // remove the call from the procedure
-
-
         // TODO: without queuing
         //$s[2]->decPendingCallCount();
 
@@ -318,31 +293,28 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testMultiRegisterWithDisagreeOnDiscloseCaller()
     {
         $s1 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $s2 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $s1->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $s2->expects($this->exactly(2))
-            ->method("sendMessage")
-            ->withConsecutive(
-                [$this->isInstanceOf('\Thruway\Message\ErrorMessage')],
-                [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')]
-            );
+                ->method("sendMessage")
+                ->withConsecutive(
+                        [$this->isInstanceOf('\Thruway\Message\ErrorMessage')], [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')]
+        );
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [
-                'disclose_caller'       => true,
-                'thruway_multiregister' => true
-            ],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [
+            'disclose_caller' => true,
+            'thruway_multiregister' => true
+                ], 'test_procedure'
         );
 
         $this->_proc->processRegister($s1, $registerMsg);
@@ -351,7 +323,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $this->_proc->processRegister($s2, $registerMsg);
 
         $registerMsg->setOptions([
-            'disclose_caller'       => true,
+            'disclose_caller' => true,
             'thruway_multiregister' => true
         ]);
         $this->_proc->processRegister($s2, $registerMsg);
@@ -360,31 +332,28 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testMultiRegisterWithDisagreeOnMultiRegister()
     {
         $s1 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $s2 = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $s1->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $s2->expects($this->exactly(2))
-            ->method("sendMessage")
-            ->withConsecutive(
-                [$this->isInstanceOf('\Thruway\Message\ErrorMessage')],
-                [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')]
-            );
+                ->method("sendMessage")
+                ->withConsecutive(
+                        [$this->isInstanceOf('\Thruway\Message\ErrorMessage')], [$this->isInstanceOf('\Thruway\Message\RegisteredMessage')]
+        );
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [
-                'disclose_caller'       => true,
-                'thruway_multiregister' => true
-            ],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [
+            'disclose_caller' => true,
+            'thruway_multiregister' => true
+                ], 'test_procedure'
         );
 
         $this->_proc->processRegister($s1, $registerMsg);
@@ -393,7 +362,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $this->_proc->processRegister($s2, $registerMsg);
 
         $registerMsg->setOptions([
-            'disclose_caller'       => true,
+            'disclose_caller' => true,
             'thruway_multiregister' => true
         ]);
         $this->_proc->processRegister($s2, $registerMsg);
@@ -402,21 +371,19 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testCallWithoutRegistration()
     {
         $session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->callback(function ($msg) {
-                $this->assertInstanceOf('\Thruway\Message\ErrorMessage', $msg);
-                $this->assertEquals('wamp.error.no_such_procedure', $msg->getErrorUri());
-                return true;
-            }));
+                ->method("sendMessage")
+                ->with($this->callback(function ($msg) {
+                            $this->assertInstanceOf('\Thruway\Message\ErrorMessage', $msg);
+                            $this->assertEquals('wamp.error.no_such_procedure', $msg->getErrorUri());
+                            return true;
+                        }));
 
         $callMsg = new \Thruway\Message\CallMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [], 'test_procedure'
         );
 
         $call = new \Thruway\Call($session, $callMsg, $this->_proc);
@@ -426,19 +393,19 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testGetCallWithRequestIDAndGetRegistrationById()
     {
         $session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $rogueSession = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $rogueSession->expects($this->exactly(1))
-            ->method("sendMessage")
-            ->withConsecutive(
-            //[$this->isInstanceOf('\Thruway\Message\RegisteredMessage'],
-                [$this->isInstanceOf('\Thruway\Message\ErrorMessage')]
-            );
+                ->method("sendMessage")
+                ->withConsecutive(
+                        //[$this->isInstanceOf('\Thruway\Message\RegisteredMessage'],
+                        [$this->isInstanceOf('\Thruway\Message\ErrorMessage')]
+        );
 
 //        $rregMsg = new \Thruway\Message\RegisterMessage(
 //            \Thruway\Common\Utils::getUniqueId(),
@@ -454,38 +421,33 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $invocationMsg = null;
 
         $session->expects($this->exactly(4))
-            ->method("sendMessage")
-            ->withConsecutive(
-                [
+                ->method("sendMessage")
+                ->withConsecutive(
+                        [
                     $this->callback(function ($msg) use (&$registeredMsg) { // registered call
                         $this->assertInstanceOf('\Thruway\Message\RegisteredMessage', $msg);
                         $registeredMsg = $msg;
 
                         return true;
                     })
-                ],
-                [
+                        ], [
                     $this->callback(function ($msg) use (&$invocationMsg) {
                         $this->assertInstanceOf('\Thruway\Message\InvocationMessage', $msg);
                         $invocationMsg = $msg;
 
                         return true;
                     })
-                ],
-                [
+                        ], [
                     $this->callback(function ($msg) {
                         $this->assertInstanceOf('\Thruway\Message\ErrorMessage', $msg);
                         $this->assertEquals('wamp.error.no_such_registration', $msg->getErrorUri());
                         return true;
                     })
-                ],
-                [$this->isInstanceOf('\Thruway\Message\UnregisteredMessage')]
-            );
+                        ], [$this->isInstanceOf('\Thruway\Message\UnregisteredMessage')]
+        );
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [], 'test_procedure'
         );
 
         $this->_proc->processRegister($session, $registerMsg);
@@ -493,9 +455,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Thruway\Message\RegisteredMessage', $registeredMsg);
 
         $callMsg = new \Thruway\Message\CallMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            "test_procedure"
+                \Thruway\Common\Utils::getUniqueId(), [], "test_procedure"
         );
 
         $call = new \Thruway\Call($session, $callMsg, $this->_proc);
@@ -514,7 +474,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($registeredMsg->getRegistrationId(), $registration->getId());
 
         $unregisterMsg = new \Thruway\Message\UnregisterMessage(
-            \Thruway\Common\Utils::getUniqueId(), $registration->getId());
+                \Thruway\Common\Utils::getUniqueId(), $registration->getId());
 
         $this->assertEquals(1, count($this->_proc->getRegistrations()));
 
@@ -532,8 +492,6 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $this->_proc->processUnregister($session, $unregisterMsg);
 
         $this->assertEquals(0, count($this->_proc->getRegistrations()));
-
-
     }
 
     public function testGetCallWithRequestIdFailure()
@@ -560,17 +518,15 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
     public function testLeave()
     {
         $session = $this->getMockBuilder('\Thruway\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
 
         $session->expects($this->once())
-            ->method("sendMessage")
-            ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
+                ->method("sendMessage")
+                ->with($this->isInstanceOf('\Thruway\Message\RegisteredMessage'));
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [],
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), [], 'test_procedure'
         );
 
         $this->_proc->processRegister($session, $registerMsg);
@@ -600,16 +556,13 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         $transportB = new \Thruway\Transport\DummyTransport();
         $sessionB = new \Thruway\Session($transportB);
 
-        $proc = new \Thruway\Procedure('some.procedure');
+        $proc = new \Thruway\Procedure('first.procedure');
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            [ "invoke" => "first" ],
-            'some.procedure'
+                \Thruway\Common\Utils::getUniqueId(), [ "invoke" => "first"], 'first.procedure'
         );
 
         $proc->processRegister($sessionA, $registerMsg);
-
         $proc->processRegister($sessionB, $registerMsg);
 
         $this->assertEquals(2, count($proc->getRegistrations()));
@@ -617,9 +570,7 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
         // call a few times - make sure that we always get proc A
         for ($i = 0; $i < 10; $i++) {
             $callMessage = new \Thruway\Message\CallMessage(
-                \Thruway\Common\Utils::getUniqueId(),
-                [],
-                'some.procedure'
+                    \Thruway\Common\Utils::getUniqueId(), [], 'first.procedure'
             );
 
             $call = new \Thruway\Call($sessionCaller, $callMessage, $proc);
@@ -632,4 +583,150 @@ class ProcedureTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(10, $sessionA->getPendingCallCount());
     }
+
+    public function testInvokeLastRegistration()
+    {
+        $transportCaller = new \Thruway\Transport\DummyTransport();
+        $sessionCaller = new \Thruway\Session($transportCaller);
+
+        $transportA = new \Thruway\Transport\DummyTransport();
+        $sessionA = new \Thruway\Session($transportA);
+
+        $transportB = new \Thruway\Transport\DummyTransport();
+        $sessionB = new \Thruway\Session($transportB);
+
+        $proc = new \Thruway\Procedure('some.procedure');
+
+        $registerMsg = new \Thruway\Message\RegisterMessage(
+                \Thruway\Common\Utils::getUniqueId(), [ "invoke" => "last"], 'some.procedure'
+        );
+
+        $proc->processRegister($sessionA, $registerMsg);
+
+        $proc->processRegister($sessionB, $registerMsg);
+
+        $this->assertEquals(2, count($proc->getRegistrations()));
+
+        // call a few times - make sure that we always get proc B
+        for ($i = 0; $i < 10; $i++) {
+            $callMessage = new \Thruway\Message\CallMessage(
+                    \Thruway\Common\Utils::getUniqueId(), [], 'some.procedure'
+            );
+
+            $call = new \Thruway\Call($sessionCaller, $callMessage, $proc);
+
+            $proc->processCall($sessionCaller, $call);
+
+            // make sure the invocation was called on the last registration
+            $this->assertEquals($call->getInvocationRequestId(), $transportB->getLastMessageSent()->getRequestId());
+        }
+
+        $this->assertEquals(10, $sessionB->getPendingCallCount());
+    }
+
+    public function testInvokeRoundRobinRegistration()
+    {
+        $transportCaller = new \Thruway\Transport\DummyTransport();
+        $sessionCaller = new \Thruway\Session($transportCaller);
+
+        $sessionsToStart = 3;
+
+        $sessions = array();
+
+        for ($i = $sessionsToStart; $i-- > 0;) {
+            $sessions[] = new \Thruway\Session(new \Thruway\Transport\DummyTransport());
+        }
+
+        $proc = new \Thruway\Procedure('round.robin.procedure');
+
+        foreach ($sessions as $session) {
+            $registerMsg = new \Thruway\Message\RegisterMessage(
+                    \Thruway\Common\Utils::getUniqueId(), [ "invoke" => "roundrobin"], 'round.robin.procedure'
+            );
+            $proc->processRegister($session, $registerMsg);
+        }
+        //make sure that the registrations have been successful
+        $this->assertEquals(count($sessions), count($proc->getRegistrations()));
+
+
+        foreach ($sessions as $session) {
+            $callMessage = new \Thruway\Message\CallMessage(
+                    \Thruway\Common\Utils::getUniqueId(), [], 'round.robin.procedure'
+            );
+
+            $call = new \Thruway\Call($sessionCaller, $callMessage, $proc);
+
+            //lets send the call
+            $proc->processCall($sessionCaller, $call);
+
+            // make sure the invocation was called as round robin
+            $this->assertEquals($call->getInvocationRequestId(), $session->getTransport()->getLastMessageSent()->getRequestId());
+
+            //make sure that pending call count is 1
+            $this->assertEquals(1, $session->getPendingCallCount());
+        }
+    }
+
+    public function testInvokeRandomRegistration()
+    {
+        //we need some sessions
+        $sessionsToInitiate = 10;
+        //we also need a big sample space to check randomness
+        $callsToSendInTotal = 30000;
+        //the standard deviation of the calls made to every registration should 
+        //not exceed {$standardDeviationThresholdPercentage}% of $callsToSendInTotal
+        $standardDeviationThresholdPercentage = 1;
+
+        $transportCaller = new \Thruway\Transport\DummyTransport();
+        $sessionCaller = new \Thruway\Session($transportCaller);
+
+        $sessions = array();
+        for ($i = $sessionsToInitiate; $i-- > 0;) {
+            $sessions[] = new \Thruway\Session(
+                    new \Thruway\Transport\DummyTransport()
+            );
+        }
+
+        $proc = new \Thruway\Procedure('random.procedure');
+
+        foreach ($sessions as $session) {
+            $registerMsg = new \Thruway\Message\RegisterMessage(
+                    \Thruway\Common\Utils::getUniqueId(), [ "invoke" => "random"], $proc->getProcedureName()
+            );
+            $proc->processRegister($session, $registerMsg);
+        }
+
+        $this->assertEquals(count($sessions), count($proc->getRegistrations()));
+
+        // call a few times 
+        for ($i = 0; $i < $callsToSendInTotal; $i++) {
+            $callMessage = new \Thruway\Message\CallMessage(
+                    \Thruway\Common\Utils::getUniqueId(), [], $proc->getProcedureName()
+            );
+
+            $call = new \Thruway\Call($sessionCaller, $callMessage, $proc);
+
+            $proc->processCall($sessionCaller, $call);
+        }
+
+        $pendingCounts = array();
+
+        foreach ($sessions as $session) {
+            $pendingCounts[] = $session->getPendingCallCount();
+        }
+
+        //get the standard deviation of the call counts
+        $fMean = array_sum($pendingCounts) / count($pendingCounts);
+        $fVariance = 0.0;
+        foreach ($pendingCounts as $i) {
+            $fVariance += pow($i - $fMean, 2);
+        }
+        $fVariance /= count($pendingCounts);
+        $stdDeviation = sqrt($fVariance);
+
+        $threshold = ($standardDeviationThresholdPercentage / 100) * $callsToSendInTotal;
+
+        $this->assertLessThanOrEqual($threshold, $stdDeviation);
+    }
+
 }


### PR DESCRIPTION
Also added a shared registration called `thruway` to accommodate the original **Thruway** RPC dispatch logic.

The changes are also backward compatible with the original `thruway_multiregister` option.