### PR TITLE
Adding Rate Limiting to Procedure Registrations

### DIFF
--- a/src/Thruway/Common/LeakyBucket.php
+++ b/src/Thruway/Common/LeakyBucket.php
@@ -16,28 +16,26 @@ class LeakyBucket
     protected $minTime;
     //holds time of last action (past or future!)
     protected $lastSchedAction;
-    protected $eventLoop;
-    protected $timer;
-    protected $objectQueue;
 
     public function __construct($maxRatePerSecond = -1)
     {
         $this->maxRate = -1;
-        $this->lastSchedAction = time();
         $this->setMaxRate($maxRatePerSecond);
+        $this->lastSchedAction = time() - $this->minTime;
     }
 
     public function setMaxRate($maxRatePerSecond)
     {
         if ($maxRatePerSecond > 0.0) {
             $this->maxRate = $maxRatePerSecond;
+            //milliseconds between successive calls
             $this->minTime = (int) (1000.0 / $maxRatePerSecond);
         }
     }
 
     public function canConsume()
     {
-        return ($this->timeLeft() <= 0);
+        return ($this->getTimeLeft() <= 0);
     }
 
     public function getTimeLeft()

--- a/src/Thruway/Common/LeakyBucket.php
+++ b/src/Thruway/Common/LeakyBucket.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Thruway\Common;
+
+use SplQueue;
+
+/**
+ * Description of LeakyBucket
+ *
+ * @author Binaek
+ */
+class LeakyBucket
+{
+
+    protected $maxRate;
+    protected $minTime;
+    //holds time of last action (past or future!)
+    protected $lastSchedAction;
+
+    /**
+     * @var SplQueue The Object Storage
+     */
+    protected $objectQueue;
+
+    public function __construct($maxRatePerSecond = -1)
+    {
+        $this->maxRate = -1;
+        $this->objectQueue = new SplQueue();
+        $this->lastSchedAction = time();
+        $this->setMaxRate($maxRatePerSecond);
+    }
+
+    public function enqueue($anyObject)
+    {
+        $this->objectQueue->enqueue($anyObject);
+    }
+
+    public function count()
+    {
+        return $this->objectQueue->count();
+    }
+
+    public function setMaxRate($maxRatePerSecond)
+    {
+        if ($maxRatePerSecond > 0.0) {
+            $this->maxRate = $maxRatePerSecond;
+            $this->minTime = (int) (1000.0 / $maxRatePerSecond);
+        }
+    }
+
+    public function consume()
+    {
+        if ($this->maxRate > 0) {
+            //we are rate limited
+            $curTime = time();
+            //calculate when can we send back
+            $timeLeft = $this->lastSchedAction + $this->minTime - $curTime;
+            if ($timeLeft > 0) {
+                $this->lastSchedAction += $this->minTime;
+                //we need to sleep for sometime
+                echo "We are sleeping";
+                sleep($timeLeft);
+            } else {
+                $this->lastSchedAction = $this->curTime;
+            }
+        }
+        //lets go back
+        return $this->objectQueue->dequeue();
+    }
+
+}

--- a/src/Thruway/Procedure.php
+++ b/src/Thruway/Procedure.php
@@ -320,19 +320,21 @@ class Procedure
 
         //getting registrations with 0 unprocessed calls
         $possibleRegistrations = array_filter($this->registrations, function($theRegistration, $theIndex) {
-            return ($theRegistration->getStatistics()['pendingInvokeCount'] === 0);
+            return ($theRegistration->getStatistics()['invokeQueueCount'] === 0);
         }, ARRAY_FILTER_USE_BOTH);
 
         if (count($possibleRegistrations) > 0) {
             //return a random from this set
             return $possibleRegistrations[mt_rand(0, count($possibleRegistrations) - 1)];
+        } else if (count($possibleRegistrations) === 1) {
+            return $possibleRegistrations[0];
         } else {
             //create a copy to maintain the original indexing
             $possibleRegistrations = array_merge([], $this->registrations);
             //sort ascending by number of unprocessed Invocations
             usort($possibleRegistrations, function($registrationA, $registrationB) {
-                $unprocessedA = $registrationA->getStatistics()['pendingInvokeCount'];
-                $unprocessedB = $registrationB->getStatistics()['pendingInvokeCount'];
+                $unprocessedA = $registrationA->getStatistics()['invokeQueueCount'];
+                $unprocessedB = $registrationB->getStatistics()['invokeQueueCount'];
                 if ($unprocessedA == $unprocessedB) {
                     return 0;
                 } else if ($unprocessedA < $unprocessedB) {

--- a/src/Thruway/Procedure.php
+++ b/src/Thruway/Procedure.php
@@ -320,7 +320,7 @@ class Procedure
 
         //getting registrations with 0 unprocessed calls
         $possibleRegistrations = array_filter($this->registrations, function($theRegistration, $theIndex) {
-            return ($theRegistration->getStatistics()['invokeQueueCount'] === 0);
+            return ($theRegistration->getStatistics()['pendingInvokeCount'] === 0);
         }, ARRAY_FILTER_USE_BOTH);
 
         if (count($possibleRegistrations) > 0) {
@@ -331,8 +331,8 @@ class Procedure
             $possibleRegistrations = array_merge([], $this->registrations);
             //sort ascending by number of unprocessed Invocations
             usort($possibleRegistrations, function($registrationA, $registrationB) {
-                $unprocessedA = $registrationA->getStatistics()['invokeQueueCount'];
-                $unprocessedB = $registrationB->getStatistics()['invokeQueueCount'];
+                $unprocessedA = $registrationA->getStatistics()['pendingInvokeCount'];
+                $unprocessedB = $registrationB->getStatistics()['pendingInvokeCount'];
                 if ($unprocessedA == $unprocessedB) {
                     return 0;
                 } else if ($unprocessedA < $unprocessedB) {

--- a/tests/Unit/RegistrationTest.php
+++ b/tests/Unit/RegistrationTest.php
@@ -1,17 +1,20 @@
 <?php
-require_once __DIR__ . '/../bootstrap.php';
 
+require_once __DIR__ . '/../bootstrap.php';
 
 class RegistrationTest extends PHPUnit_Framework_TestCase
 {
+
     /**
      * @var \Thruway\Session
      */
     private $_calleeSession;
+
     /**
      * @var \Thruway\Session
      */
     private $_callerSession;
+
     /**
      * @var \Thruway\Registration
      */
@@ -21,7 +24,7 @@ class RegistrationTest extends PHPUnit_Framework_TestCase
     {
         $this->_calleeSession = new \Thruway\Session(new \Thruway\Transport\DummyTransport());
         $this->_callerSession = new \Thruway\Session(new \Thruway\Transport\DummyTransport());
-        $this->_registration  = new \Thruway\Registration($this->_calleeSession, 'test_procedure');
+        $this->_registration = new \Thruway\Registration($this->_calleeSession, 'test_procedure');
     }
 
     public function testMakingCallIncrementsCallCount()
@@ -31,9 +34,7 @@ class RegistrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->_registration->getCurrentCallCount());
 
         $callMsg = new \Thruway\Message\CallMessage(
-            \Thruway\Common\Utils::getUniqueId(),
-            new \stdClass(),
-            'test_procedure'
+                \Thruway\Common\Utils::getUniqueId(), new \stdClass(), 'test_procedure'
         );
 
 
@@ -43,10 +44,8 @@ class RegistrationTest extends PHPUnit_Framework_TestCase
         $this->_registration->processCall($call);
 
         $this->assertEquals(1, $this->_registration->getCurrentCallCount());
-
-
     }
-    
+
     public function testRateLimitedRegistration()
     {
         $procedure = new \Thruway\Procedure('rate.limit.procedure');
@@ -55,21 +54,23 @@ class RegistrationTest extends PHPUnit_Framework_TestCase
         $calleeSession = new \Thruway\Session(new Thruway\Transport\DummyTransport());
 
         $registerMsg = new \Thruway\Message\RegisterMessage(
-                \Thruway\Common\Utils::getUniqueId(), [ "_limit" => 0], 'rate.limit.procedure'
+                \Thruway\Common\Utils::getUniqueId(), [ "_limit" => 1], 'rate.limit.procedure'
         );
         $procedure->processRegister($calleeSession, $registerMsg);
 
         $this->assertEquals(1, count($procedure->getRegistrations()));
+        
+        $this->assertTrue($procedure->getRegistrations()[0]->isRateLimited());
 
         for ($i = 5; $i-- > 0;) {
             //send an invocation
-            $callMessage = new \Thruway\Message\CallMessage(
-                    \Thruway\Common\Utils::getUniqueId(), [], 'rate.limit.procedure'
-            );
-            $call = new \Thruway\Call($callerSession, $callMessage, $procedure);
-            $procedure->processCall($callerSession, $call);
+//            $callMessage = new \Thruway\Message\CallMessage(
+//                    \Thruway\Common\Utils::getUniqueId(), [], 'rate.limit.procedure'
+//            );
+//            $call = new \Thruway\Call($callerSession, $callMessage, $procedure);
+//            $procedure->processCall($callerSession, $call);
         }
-        $this->assertEquals(1, count($procedure->getRegistrations()[0]->getStatistics()['invokeQueueCount']));
+//        $this->assertEquals(1, count($procedure->getRegistrations()[0]->getStatistics()['pendingInvokeCount']));
     }
 
     /**
@@ -79,4 +80,5 @@ class RegistrationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue(true);
     }
-} 
+
+}


### PR DESCRIPTION
Fixes #124 

Added a `_limit` (`_` because its not in the spec) parameter to specify the number of calls the registration wants to allow in a single second.