### PR TITLE
Fixed incompatibility with Symfony3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cboden/ratchet": "0.3.*",
         "ratchet/pawl": "0.1.*",
         "psr/log": "~1",
-        "guzzle/guzzle": "~3.9"
+        "guzzlehttp/guzzle": "6.1.*"
     },
     "suggest": {
 	    "ext-mcrypt":"If you want to use WAMP-CRA for authentication"


### PR DESCRIPTION
guzzle/guzzle is deprecated in favor of guzzlehttp/guzzle