### PR TITLE
Fix for DNS resolve issues (docker)

### DIFF
--- a/src/Thruway/Transport/PawlTransportProvider.php
+++ b/src/Thruway/Transport/PawlTransportProvider.php
@@ -35,7 +35,17 @@ class PawlTransportProvider extends AbstractClientTransportProvider
      */
     function __construct($URL = "ws://127.0.0.1:8080/")
     {
-        $this->URL     = $URL;
+        $protocoll = "";
+        if (strpos($URL, '://') > -1) {
+            $protocoll = substr($URL, 0, strpos($URL, ':')+3);
+            $URL = substr($URL, strpos($URL, ':')+3);
+        }
+        $port = "";
+        if (strpos($URL, ':') > -1) {
+            $port = substr($URL, strpos($URL, ':'));
+            $URL = substr($URL, 0, strpos($URL, ':'));
+        }
+        $this->URL     = $protocoll . gethostbyname($URL) . $port;
     }
 
     /**


### PR DESCRIPTION
For all having issues with using FQDN.
This is a permanent solution to use alias or a domain name and translate it into an IP.