### PR TITLE
add authextra into session meta info

### DIFF
--- a/src/Thruway/Session.php
+++ b/src/Thruway/Session.php
@@ -222,11 +222,13 @@ class Session extends AbstractSession implements RealmModuleInterface
             $authMethod = $this->getAuthenticationDetails()->getAuthMethod();
             $authRole   = $this->getAuthenticationDetails()->getAuthRole();
             $authRoles  = $this->getAuthenticationDetails()->getAuthRoles();
+            $authExtra  = $this->getAuthenticationDetails()->getAuthExtra();
         } else {
             $authId     = "anonymous";
             $authMethod = "anonymous";
             $authRole   = "anonymous";
             $authRoles  = [];
+            $authExtra  = null;
         }
 
         return [
@@ -236,6 +238,7 @@ class Session extends AbstractSession implements RealmModuleInterface
           "authrole"      => $authRole,
           "authroles"     => $authRoles,
           "authmethod"    => $authMethod,
+          "authextra"     => $authExtra,
           "session"       => $this->getSessionId(),
           "role_features" => $this->getRoleFeatures()
         ];


### PR DESCRIPTION
Hi guys!

In my app I use Thruway router and I’ve implemented server-side wamp client subscriber for meta events like on_join/on_leave. In event handlers of such events, I’d like to use client’s info such as IP, user-agent, header and so on for save that info into redis. So for transfer such kind of  data I want to use authExtra from authenticationDetails.

I’ve already found a workaround without any library changes. I’ve  overridden Session::getMetaInfo() method and also overridden method Router::createNewSession() in subclasses. But I think it would be great if the library will support extra auth data in meta events out of box.