### PR TITLE
Authentication Example PHP Client fix

### DIFF
--- a/Examples/Authentication/StartClient.php
+++ b/Examples/Authentication/StartClient.php
@@ -1,12 +1,14 @@
 <?php
 
-require "../bootstrap.php";
+require __DIR__ . "/../bootstrap.php";
 require 'SimpleClientAuth.php';
+
+$url = "ws://127.0.0.1:9090/";
 
 $client = new \Thruway\Peer\Client('somerealm');
 
 $client->addClientAuthenticator(new SimpleClientAuth());
 
-$client->addTransportProvider(new \Thruway\Transport\PawlTransportProvider());
+$client->addTransportProvider(new \Thruway\Transport\PawlTransportProvider($url));
 
 $client->start();

--- a/Examples/Authentication/StartRouter.php
+++ b/Examples/Authentication/StartRouter.php
@@ -1,5 +1,5 @@
 <?php
-require "../bootstrap.php";
+require __DIR__ . "/../bootstrap.php";
 require 'SimpleAuthProviderClient.php';
 
 use Thruway\Peer\Router;


### PR DESCRIPTION
Changed require statement to allow execution from project root, as other examples, and added missing host:port to PawlTransportProvider to fix example