### PR TITLE
add compability with autobahnjs

### DIFF
--- a/src/Call.php
+++ b/src/Call.php
@@ -299,10 +299,12 @@ class Call
             if ($this->getRegistration()->getDiscloseCaller() === true && $this->getCallerSession()->getAuthenticationDetails()) {
                 $authenticationDetails = $this->getCallerSession()->getAuthenticationDetails();
                 $details               = [
-                    'caller'     => $this->getCallerSession()->getSessionId(),
-                    'authid'     => $authenticationDetails->getAuthId(),
-                    'authrole'   => $authenticationDetails->getAuthRole(),
-                    'authroles'  => $authenticationDetails->getAuthRoles(),
+                    'caller' => $this->getCallerSession()->getSessionId(),
+                    'authid' => $authenticationDetails->getAuthId(),
+                    'authrole' => $authenticationDetails->getAuthRole(),
+                    'caller_authid' => $authenticationDetails->getAuthId(),
+                    'caller_authrole' => $authenticationDetails->getAuthRole(),
+                    'authroles' => $authenticationDetails->getAuthRoles(),
                     'authmethod' => $authenticationDetails->getAuthMethod(),
                 ];
 


### PR DESCRIPTION
autobahnjs could not process caller disclose, because they use different property naming, this fix will correct that.