### PR TITLE
added support for new Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ matrix:
       env:
         - dependencies=highest
         - dropPlatform=false
-
+  allow_failures:
+    - php: nightly
 
 before_install:
     - export PATH=$HOME/.local/bin:$PATH

--- a/composer.json
+++ b/composer.json
@@ -28,18 +28,25 @@
     "bin": [
         "bin/thruway"
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/kuraobi/raw-socket-transport"
+        }
+    ],
     "require": {
         "php": ">=5.6",
-        "symfony/event-dispatcher": "^2.7|^3.0|^4.0",
+        "cboden/ratchet": "^0.4",
+        "guzzlehttp/psr7": "^1.4",
+        "symfony/event-dispatcher": "^2.7|^3.0|^4.0|^5.0",
         "voryx/thruway-common": "^1.0.5",
         "thruway/client": "^0.5.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4.3",
-        "react/promise": "^2.3.0",
-        "thruway/ratchet-transport": "^0.5.0"
+        "react/promise": "^2.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5.4",
+        "phpunit/phpunit": "^6.5.14",
         "thruway/pawl-transport": "^0.5.0",
-        "thruway/raw-socket-transport": "^0.5.0"
+        "thruway/raw-socket-transport": "dev-symfony5 as 0.6.0"
     }
 }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -2,7 +2,14 @@
 
 namespace Thruway\Event;
 
-class Event extends \Symfony\Component\EventDispatcher\Event
-{
+if (class_exists(\Symfony\Contracts\EventDispatcher\Event::class)) {
+    class Event extends \Symfony\Contracts\EventDispatcher\Event
+    {
 
+    }
+} else {
+    class Event extends \Symfony\Component\EventDispatcher\Event
+    {
+
+    }
 }

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -2,15 +2,56 @@
 
 namespace Thruway\Event;
 
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Thruway\Module\RealmModuleInterface;
 
-class EventDispatcher extends \Symfony\Component\EventDispatcher\EventDispatcher implements EventDispatcherInterface
-{
-    public function addRealmSubscriber(RealmModuleInterface $subscriber)
+/**
+ * To support both older and newer versions of Symfony, we rely on an "backwardsCompatibleDispatch" method
+ * which uses the new parameter order and translates the call.
+ * Once support for Symfony < 4.3 is dropped, we can simply use ->dispatch() with the LegacyEventDispatcherProxy
+ */
+if (class_exists(\Symfony\Component\EventDispatcher\Event::class) && !class_exists(LegacyEventDispatcherProxy::class)) {
+    /**
+     * Symfony < 4.3, add support for new parameter order without using the LegacyEventDispatcherProxy
+     */
+    class EventDispatcher extends \Symfony\Component\EventDispatcher\EventDispatcher implements EventDispatcherInterface
     {
-        $events = $subscriber->getSubscribedRealmEvents();
-        foreach ($events as $eventName => $event) {
-            $this->addListener($eventName, [$subscriber, $event[0]], $event[1]);
+        public function addRealmSubscriber(RealmModuleInterface $subscriber)
+        {
+            $events = $subscriber->getSubscribedRealmEvents();
+            foreach ($events as $eventName => $event) {
+                $this->addListener($eventName, [$subscriber, $event[0]], $event[1]);
+            }
+        }
+
+        public function backwardsCompatibleDispatch($event, $eventName = null)
+        {
+            return $this->dispatch($eventName, $event);
+        }
+    }
+} else {
+    /**
+     * Symfony >= 4.3, only accept the new parameter order.
+     * Both orders can be accepted for ^4.3 by using the LegacyEventDispatcherProxy
+     */
+    class EventDispatcher extends \Symfony\Component\EventDispatcher\EventDispatcher implements EventDispatcherInterface
+    {
+        public function addRealmSubscriber(RealmModuleInterface $subscriber)
+        {
+            $events = $subscriber->getSubscribedRealmEvents();
+            foreach ($events as $eventName => $event) {
+                $this->addListener($eventName, [$subscriber, $event[0]], $event[1]);
+            }
+        }
+
+        public function backwardsCompatibleDispatch($event, $eventName = null)
+        {
+            if (class_exists(\Symfony\Component\EventDispatcher\Event::class)) {
+                // Symfony >=4.3 and < 5.0, use the proxy
+                return LegacyEventDispatcherProxy::decorate($this)->dispatch($event, $eventName);
+            }
+            // Symfony >=5.0, just forward the call
+            return $this->dispatch($event, $eventName);
         }
     }
 }

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -4,7 +4,18 @@ namespace Thruway\Event;
 
 use Thruway\Module\RealmModuleInterface;
 
-interface EventDispatcherInterface extends \Symfony\Component\EventDispatcher\EventDispatcherInterface
-{
-    public function addRealmSubscriber(RealmModuleInterface $subscriber);
+if (interface_exists(\Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class)) {
+    interface EventDispatcherInterface extends \Symfony\Contracts\EventDispatcher\EventDispatcherInterface
+    {
+        public function addRealmSubscriber(RealmModuleInterface $subscriber);
+
+        public function backwardsCompatibleDispatch($event, $eventName = null);
+    }
+} else {
+    interface EventDispatcherInterface extends \Symfony\Component\EventDispatcher\EventDispatcherInterface
+    {
+        public function addRealmSubscriber(RealmModuleInterface $subscriber);
+
+        public function backwardsCompatibleDispatch($event, $eventName = null);
+    }
 }

--- a/src/Peer/Router.php
+++ b/src/Peer/Router.php
@@ -124,7 +124,7 @@ class Router implements RouterInterface, EventSubscriberInterface
 
         $this->started = true;
 
-        $this->eventDispatcher->dispatch('router.start', new RouterStartEvent());
+        $this->eventDispatcher->backwardsCompatibleDispatch(new RouterStartEvent(), 'router.start');
 
         if ($runLoop) {
             Logger::info($this, 'Starting loop');
@@ -137,7 +137,7 @@ class Router implements RouterInterface, EventSubscriberInterface
      */
     public function stop($gracefully = true)
     {
-        $this->getEventDispatcher()->dispatch('router.stop', new RouterStopEvent());
+        $this->getEventDispatcher()->backwardsCompatibleDispatch(new RouterStopEvent(), 'router.stop');
     }
 
     /**

--- a/src/RealmManager.php
+++ b/src/RealmManager.php
@@ -156,7 +156,7 @@ class RealmManager extends Module\RouterModule implements RealmModuleInterface
 
         $this->realms[$realm->getRealmName()] = $realm;
 
-        $this->router->getEventDispatcher()->dispatch('new_realm', new NewRealmEvent($realm));
+        $this->router->getEventDispatcher()->backwardsCompatibleDispatch(new NewRealmEvent($realm), 'new_realm');
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -134,7 +134,7 @@ class Session extends AbstractSession implements RealmModuleInterface
                 // metaevent
                 $this->getRealm()->publishMeta('wamp.metaevent.session.on_leave', [$this->getMetaInfo()]);
             }
-            $this->dispatcher->dispatch('LeaveRealm', new LeaveRealmEvent($this->realm, $this));
+            $this->dispatcher->backwardsCompatibleDispatch(new LeaveRealmEvent($this->realm, $this), 'LeaveRealm');
 
             $this->realm = null;
         }
@@ -339,8 +339,8 @@ class Session extends AbstractSession implements RealmModuleInterface
         $shortName = (new \ReflectionClass($message))->getShortName();
 
         if ($message instanceof HelloMessage) {
-            $this->dispatcher->dispatch('Pre' . $shortName . 'Event', new MessageEvent($this, $message));
+            $this->dispatcher->backwardsCompatibleDispatch(new MessageEvent($this, $message), 'Pre' . $shortName . 'Event');
         }
-        $this->dispatcher->dispatch($eventNamePrefix . $shortName . 'Event', new MessageEvent($this, $message));
+        $this->dispatcher->backwardsCompatibleDispatch(new MessageEvent($this, $message), $eventNamePrefix . $shortName . 'Event');
     }
 }

--- a/src/Transport/InternalClientTransportProvider.php
+++ b/src/Transport/InternalClientTransportProvider.php
@@ -61,7 +61,7 @@ class InternalClientTransportProvider extends AbstractRouterTransportProvider
         $this->session = $session;
 
         // connect the transport to the Router/Peer
-        $this->router->getEventDispatcher()->dispatch('connection_open', new ConnectionOpenEvent($session));
+        $this->router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), 'connection_open');
 
         // open the client side
         $this->internalClient->onOpen($clientTransport);

--- a/src/Transport/RatchetTransport.php
+++ b/src/Transport/RatchetTransport.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Thruway\Transport;
+
+use GuzzleHttp\Psr7\Request;
+use Ratchet\RFC6455\Messaging\Frame;
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+use Thruway\Message\Message;
+
+/**
+ * class RatchetTransport
+ */
+class RatchetTransport extends AbstractTransport
+{
+    /**
+     * @var \Ratchet\ConnectionInterface
+     */
+    private $conn;
+
+    /**
+     * @var mixed
+     */
+    private $pingSeq;
+
+    /**
+     * @var array
+     */
+    private $pingRequests;
+
+    /**
+     * Constructor
+     *
+     * @param \Ratchet\ConnectionInterface $conn
+     * @param \React\EventLoop\LoopInterface $loop
+     */
+    function __construct($conn, LoopInterface $loop)
+    {
+        $this->conn         = $conn;
+        $this->pingSeq      = 1234;
+        $this->pingRequests = [];
+        $this->loop         = $loop;
+    }
+
+    /**
+     * Send message
+     *
+     * @param \Thruway\Message\Message $msg
+     */
+    public function sendMessage(Message $msg)
+    {
+        $this->conn->send($this->getSerializer()->serialize($msg));
+    }
+
+    /**
+     * Close transport
+     */
+    public function close()
+    {
+        $this->conn->close();
+    }
+
+    /**
+     * Get transport details
+     *
+     * @return array
+     */
+    public function getTransportDetails()
+    {
+        $transportAddress = null;
+        $transportAddress = $this->conn->remoteAddress;
+
+        /** @var Request $request */
+        $request     = $this->conn->httpRequest;
+        $headers     = $request->getHeaders();
+        $queryParams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
+        $cookies     = $request->getHeader("Cookie");
+        $url         = $request->getUri()->getPath();
+
+        return [
+          "type"             => "ratchet",
+          "transport_address" => $transportAddress,
+          "headers"          => $headers,
+          "url"              => $url,
+          "query_params"     => $queryParams,
+          "cookies"          => $cookies,
+        ];
+    }
+
+    /**
+     * Ping
+     *
+     * @param int $timeout
+     * @return \React\Promise\Promise
+     */
+    public function ping($timeout = 10)
+    {
+        $payload = $this->pingSeq;
+
+        $this->conn->send(new Frame($payload, true, Frame::OP_PING));
+
+        $seq = $this->pingSeq;
+
+        $this->pingSeq++;
+
+        if ($timeout > 0) {
+            $timer = $this->loop->addTimer($timeout, function () use ($seq) {
+                if (isset($this->pingRequests[$seq])) {
+                    $this->pingRequests[$seq]['deferred']->reject('timeout');
+                    unset($this->pingRequests[$seq]);
+                }
+
+            });
+
+            $deferred = new Deferred();
+
+            $this->pingRequests[$seq] = [
+              'seq'      => $seq,
+              'deferred' => $deferred,
+              'timer'    => $timer
+            ];
+
+            return $deferred->promise();
+        }
+
+    }
+
+    /**
+     * Handle on pong
+     *
+     * @param Frame $frame
+     */
+    public function onPong(Frame $frame)
+    {
+        $seq = $frame->getPayload();
+
+        if (isset($this->pingRequests[$seq]) && isset($this->pingRequests[$seq]['deferred'])) {
+            $this->pingRequests[$seq]['deferred']->resolve($seq);
+            /* @var $timer \React\EventLoop\Timer\TimerInterface */
+            $timer = $this->pingRequests[$seq]['timer'];
+            $timer->cancel();
+
+            unset($this->pingRequests[$seq]);
+        }
+    }
+}

--- a/src/Transport/RatchetTransportProvider.php
+++ b/src/Transport/RatchetTransportProvider.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Thruway\Transport;
+
+use Ratchet\RFC6455\Messaging\Frame;
+use React\EventLoop\LoopInterface;
+use Thruway\Event\ConnectionCloseEvent;
+use Thruway\Event\ConnectionOpenEvent;
+use Thruway\Event\RouterStartEvent;
+use Thruway\Event\RouterStopEvent;
+use Thruway\Exception\DeserializationException;
+use Thruway\Logging\Logger;
+use Thruway\Message\HelloMessage;
+use Thruway\Serializer\JsonSerializer;
+use Ratchet\ConnectionInterface;
+use Ratchet\Http\HttpServer;
+use Ratchet\MessageComponentInterface;
+use Ratchet\Server\IoServer;
+use Ratchet\WebSocket\WsServer;
+use Ratchet\WebSocket\WsServerInterface;
+use React\Socket\Server as Reactor;
+use Thruway\Session;
+
+/**
+ * Class RatchetTransportProvider
+ *
+ * @package Thruway\Transport
+ */
+class RatchetTransportProvider extends AbstractRouterTransportProvider implements MessageComponentInterface, WsServerInterface
+{
+    /**
+     * @var string
+     */
+    private $address;
+
+    /**
+     * @var string|int
+     */
+    private $port;
+
+    /**
+     * @var \Ratchet\Server\IoServer
+     */
+    private $server;
+
+    /**
+     * @var \SplObjectStorage
+     */
+    private $sessions;
+
+    /**
+     * @var WsServer
+     */
+    private $ws;
+
+    /**
+     * Constructor
+     *
+     * @param string $address
+     * @param string|int $port
+     */
+    public function __construct($address = "127.0.0.1", $port = 8080)
+    {
+        $this->port     = $port;
+        $this->address  = $address;
+        $this->sessions = new \SplObjectStorage();
+        $this->ws       = new WsServer($this);
+    }
+
+    /**
+     * Interface stuff
+     */
+
+    /** @inheritdoc */
+    public function getSubProtocols()
+    {
+        return ['wamp.2.json'];
+    }
+
+
+    /** @inheritdoc */
+    public function onOpen(ConnectionInterface $conn)
+    {
+        Logger::debug($this, "RatchetTransportProvider::onOpen");
+
+        $transport = new RatchetTransport($conn, $this->loop);
+
+        // this will need to be a little more dynamic at some point
+        $transport->setSerializer(new JsonSerializer());
+
+        $transport->setTrusted($this->trusted);
+
+        $session = $this->router->createNewSession($transport);
+
+        $this->sessions->attach($conn, $session);
+
+        $this->router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
+    }
+
+    /** @inheritdoc */
+    public function onClose(ConnectionInterface $conn)
+    {
+        /** @var Session $session */
+        $session = $this->sessions[$conn];
+
+        $this->sessions->detach($conn);
+
+        $this->router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionCloseEvent($session), 'connection_close');
+
+        unset($this->sessions[$conn]);
+
+        Logger::info($this, "Ratchet has closed");
+    }
+
+    /** @inheritdoc */
+    public function onError(ConnectionInterface $conn, \Exception $e)
+    {
+        Logger::error($this, "onError...");
+    }
+
+    /** @inheritdoc */
+    public function onMessage(ConnectionInterface $from, $msg)
+    {
+        Logger::debug($this, "onMessage: ({$msg})");
+        /** @var Session $session */
+        $session = $this->sessions[$from];
+
+        try {
+            //$this->router->onMessage($transport, $transport->getSerializer()->deserialize($msg));
+            $msg = $session->getTransport()->getSerializer()->deserialize($msg);
+
+            if ($msg instanceof HelloMessage) {
+
+                $details = $msg->getDetails();
+
+                $details->transport = (object) $session->getTransport()->getTransportDetails();
+
+                $msg->setDetails($details);
+            }
+
+            $session->dispatchMessage($msg);
+        } catch (DeserializationException $e) {
+            Logger::alert($this, "Deserialization exception occurred.");
+        } catch (\Exception $e) {
+            Logger::alert($this, "Exception occurred during onMessage: ".$e->getMessage());
+        }
+    }
+
+    /**
+     * Handle on pong
+     *
+     * @param \Ratchet\ConnectionInterface $from
+     * @param Frame $frame
+     */
+    public function onPong(ConnectionInterface $from, Frame $frame)
+    {
+        $transport = $this->sessions[$from];
+
+        if (method_exists($transport, 'onPong')) {
+            $transport->onPong($frame);
+        }
+    }
+
+    public function handleRouterStart(RouterStartEvent $event)
+    {
+
+        $socket = new Reactor('tcp://' . $this->address . ':' . $this->port, $this->loop);
+
+        Logger::info($this, "Websocket listening on ".$this->address.":".$this->port);
+
+        $this->server = new IoServer(new HttpServer($this->ws), $socket, $this->loop);
+    }
+
+    public function enableKeepAlive(LoopInterface $loop, $interval = 30)
+    {
+        $this->ws->enableKeepAlive($loop, $interval);
+    }
+
+    public function handleRouterStop(RouterStopEvent $event)
+    {
+        if ($this->server) {
+            $this->server->socket->close();
+        }
+
+        foreach ($this->sessions as $k) {
+            $this->sessions[$k]->shutdown();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+          "router.start" => ["handleRouterStart", 10],
+          "router.stop"  => ["handleRouterStop", 10]
+        ];
+    }
+}

--- a/tests/Crossbar/CrossbarTest.php
+++ b/tests/Crossbar/CrossbarTest.php
@@ -7,7 +7,7 @@ use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use Thruway\ClientSession;
 
-class CrossbarTest extends PHPUnit_Framework_TestCase
+class CrossbarTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/Message/MessageTest.php
+++ b/tests/Message/MessageTest.php
@@ -15,7 +15,7 @@ use Thruway\Message\Message;
 use Thruway\Message\ResultMessage;
 use Thruway\Serializer\JsonSerializer;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+class MessageTest extends \PHPUnit\Framework\TestCase {
     function testSomething() {
         $this->assertTrue(true);
     }

--- a/tests/Message/RegisterMessageTest.php
+++ b/tests/Message/RegisterMessageTest.php
@@ -11,7 +11,7 @@ use Thruway\Message\RegisterMessage;
  *
  * <code>[REGISTER, Request|id, Options|dict, Procedure|uri]</code>
  */
-class RegisterMessageTest extends \PHPUnit_Framework_TestCase
+class RegisterMessageTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testEmptyArrayOptions()

--- a/tests/Message/SubscribeMessageTest.php
+++ b/tests/Message/SubscribeMessageTest.php
@@ -11,7 +11,7 @@ use Thruway\Message\SubscribeMessage;
  *
  * <code>[SUBSCRIBE, Request|id, Options|dict, Topic|uri]</code>
  */
-class SubscribeMessageTest extends \PHPUnit_Framework_TestCase
+class SubscribeMessageTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testEmptyArrayOptions()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,7 @@
 
 namespace Thruway;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
 
 }

--- a/tests/Unit/Messages/HelloMessageTest.php
+++ b/tests/Unit/Messages/HelloMessageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HelloMessageTest extends PHPUnit_Framework_TestCase
+class HelloMessageTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @expectedException InvalidArgumentException

--- a/tests/Unit/Messages/PublishMessageTest.php
+++ b/tests/Unit/Messages/PublishMessageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class PublishMessageTest extends \PHPUnit_Framework_TestCase
+class PublishMessageTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testPublishBlackWhiteListing()

--- a/tests/Unit/Messages/WelcomeMessageTest.php
+++ b/tests/Unit/Messages/WelcomeMessageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class WelcomeMessageTest extends \PHPUnit_Framework_TestCase
+class WelcomeMessageTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testBrokerFeatures()

--- a/tests/Unit/Peer/RouterTest.php
+++ b/tests/Unit/Peer/RouterTest.php
@@ -1,10 +1,12 @@
 <?php
+
+use Thruway\Event\ConnectionOpenEvent;
 use Thruway\Message\WelcomeMessage;
 
 /**
  * Class RouterTest
  */
-class RouterTest extends \PHPUnit_Framework_TestCase
+class RouterTest extends \PHPUnit\Framework\TestCase
 {
 
     /**
@@ -55,7 +57,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $session = new \Thruway\Session($transport);
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         $this->assertGreaterThan(0, count($router->managerGetSessionCount()));
 
@@ -78,7 +80,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $session = new \Thruway\Session($transport);
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         return ['router' => $router, 'session' => $session];
     }
@@ -415,7 +417,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(["type" => "ratchet", "transport_address" => "127.0.0.1"]));
 
         //Simulate onOpen
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         //Simulate a HelloMessage
         $helloMessage = new \Thruway\Message\HelloMessage("test.realm", []);
@@ -472,7 +474,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $session = new \Thruway\Session($transport);
 
         //Simulate onOpen
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         //Simulate HelloMessage
         $helloMessage = new \Thruway\Message\HelloMessage("test.realm2", []);
@@ -534,7 +536,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $session = new \Thruway\Session($transport);
 
         //Simulate onOpen
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         //Simulate a AbortMessage
         $abortMessage = new \Thruway\Message\AbortMessage(["message" => "Client is shutting down"], "wamp.error.system_shutdown");
@@ -576,7 +578,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $session = new \Thruway\Session($transport);
 
         //Simulate onOpen
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         //Simulate a GoodbyeMessage
         $goodbyeMessage = new \Thruway\Message\GoodbyeMessage(["message" => "Client is shutting down"],
@@ -619,7 +621,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $session = new \Thruway\Session($transport);
 
         //Simulate onOpen
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         //Simulate a HelloMessage with an empty Realm
         $helloMessage = new \Thruway\Message\HelloMessage("", []);
@@ -677,9 +679,9 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
 
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session1));
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session2));
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionPublisher));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session1), "connection_open");
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session2), "connection_open");
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionPublisher), "connection_open");
 
         // send in a few hellos
         $helloMsg = new \Thruway\Message\HelloMessage("realm_issue53", (object)[]);
@@ -779,8 +781,8 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $sessionStateHandler = new \Thruway\Session($transportStateHandler);
         $sessionSubscriber = new \Thruway\Session($transportSubscriber);
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionStateHandler));
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionSubscriber));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionStateHandler), "connection_open");
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionSubscriber), "connection_open");
 
         $hello = new \Thruway\Message\HelloMessage('state.test.realm', (object)[]);
 
@@ -886,8 +888,8 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $sessionStateHandler = new \Thruway\Session($transportStateHandler);
         $sessionSubscriber = new \Thruway\Session($transportSubscriber);
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionStateHandler));
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionSubscriber));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionStateHandler), "connection_open");
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionSubscriber), "connection_open");
 
         $hello = new \Thruway\Message\HelloMessage('state.test.realm', (object)[]);
 
@@ -992,8 +994,8 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $sessionStateHandler = new \Thruway\Session($transportStateHandler);
         $sessionSubscriber = new \Thruway\Session($transportSubscriber);
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionStateHandler));
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionSubscriber));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionStateHandler), "connection_open");
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionSubscriber), "connection_open");
 
         $hello = new \Thruway\Message\HelloMessage('state.test.realm', (object)[]);
 
@@ -1095,8 +1097,8 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $sessionStateHandler = new \Thruway\Session($transportStateHandler);
         $sessionSubscriber = new \Thruway\Session($transportSubscriber);
 
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionStateHandler));
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($sessionSubscriber));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionStateHandler), "connection_open");
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($sessionSubscriber), "connection_open");
 
         $hello = new \Thruway\Message\HelloMessage('state.test.realm', (object)[]);
 
@@ -1216,7 +1218,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $transport = new \Thruway\Transport\DummyTransport();
         $session = $router->createNewSession($transport);
         $prevMsg = null;
-        $router->getEventDispatcher()->dispatch("connection_open", new \Thruway\Event\ConnectionOpenEvent($session));
+        $router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), "connection_open");
 
         $fromRouter = [];
 

--- a/tests/Unit/ProcedureTest.php
+++ b/tests/Unit/ProcedureTest.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/../bootstrap.php';
 
-class ProcedureTest extends PHPUnit_Framework_TestCase
+class ProcedureTest extends PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/Unit/RealmManagerTest.php
+++ b/tests/Unit/RealmManagerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class RealmManagerTest extends PHPUnit_Framework_TestCase {
+class RealmManagerTest extends PHPUnit\Framework\TestCase {
 
     /**
      * @expectedException \Thruway\Exception\RealmNotFoundException

--- a/tests/Unit/RealmTest.php
+++ b/tests/Unit/RealmTest.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__.'/../bootstrap.php';
 
-class RealmTest extends PHPUnit_Framework_TestCase
+class RealmTest extends PHPUnit\Framework\TestCase
 {
     private $_sessions;
 

--- a/tests/Unit/RegistrationTest.php
+++ b/tests/Unit/RegistrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class RegistrationTest extends PHPUnit_Framework_TestCase
+class RegistrationTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @var \Thruway\Session

--- a/tests/Unit/Role/BrokerTest.php
+++ b/tests/Unit/Role/BrokerTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../bootstrap.php';
 
-class BrokerTest extends PHPUnit_Framework_TestCase
+class BrokerTest extends PHPUnit\Framework\TestCase
 {
     public function testUnsubscribeFromNonExistentSubscription()
     {

--- a/tests/Unit/Role/DealerTest.php
+++ b/tests/Unit/Role/DealerTest.php
@@ -18,7 +18,7 @@ use Thruway\Role\Dealer;
 use Thruway\Session;
 use Thruway\Transport\DummyTransport;
 
-class DealerTest extends PHPUnit_Framework_TestCase {
+class DealerTest extends PHPUnit\Framework\TestCase {
     /** @var \Thruway\Message\HelloMessage */
     private $_helloMessage;
 

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class SessionTest extends PHPUnit_Framework_TestCase {
+class SessionTest extends PHPUnit\Framework\TestCase {
     public function testTransportSendMessage() {
         $transport = $this->getMockBuilder('\Thruway\Transport\TransportInterface')
             ->getMock();

--- a/tests/Unit/Subscription/StateHandlerRegistrationTest.php
+++ b/tests/Unit/Subscription/StateHandlerRegistrationTest.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/../../bootstrap.php';
 
-class StateHandlerRegistrationTest extends PHPUnit_Framework_TestCase {
+class StateHandlerRegistrationTest extends PHPUnit\Framework\TestCase {
     public function testSubgroupStateHandlerCheck() {
         $session = $this->getMockBuilder('Thruway\Session')
             ->disableOriginalConstructor()

--- a/tests/WAMP/AbortingRouterTest.php
+++ b/tests/WAMP/AbortingRouterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class AbortingRouterTest extends \PHPUnit_Framework_TestCase {
+class AbortingRouterTest extends \PHPUnit\Framework\TestCase {
     public function testAbortFollowingHello() {
         $this->_testResult = null;
         $this->_error = null;

--- a/tests/WAMP/AuthExtraTest.php
+++ b/tests/WAMP/AuthExtraTest.php
@@ -30,7 +30,7 @@ class TheAuthProvider extends \Thruway\Authentication\AbstractAuthProviderClient
 
 }
 
-class AuthExtraTest extends PHPUnit_Framework_TestCase {
+class AuthExtraTest extends PHPUnit\Framework\TestCase {
     /*
      * This is a complex test - should do this a better way
      */

--- a/tests/WAMP/AuthorizingRealmTest.php
+++ b/tests/WAMP/AuthorizingRealmTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class AuthorizingRealmTest extends PHPUnit_Framework_TestCase {
+class AuthorizingRealmTest extends \PHPUnit\Framework\TestCase {
     /**
      * @var \Thruway\Connection
      */

--- a/tests/WAMP/DiscloseCallerTest.php
+++ b/tests/WAMP/DiscloseCallerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class DiscloseCallerTest extends PHPUnit_Framework_TestCase
+class DiscloseCallerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Thruway\Connection

--- a/tests/WAMP/DisclosePublisherTest.php
+++ b/tests/WAMP/DisclosePublisherTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class DisclosePublisherTest extends PHPUnit_Framework_TestCase
+class DisclosePublisherTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Thruway\Connection

--- a/tests/WAMP/EndToEndTest.php
+++ b/tests/WAMP/EndToEndTest.php
@@ -4,7 +4,7 @@ use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use Thruway\ClientSession;
 
-class EndToEndTest extends PHPUnit_Framework_TestCase
+class EndToEndTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/WAMP/FeatureAnnouncementTest.php
+++ b/tests/WAMP/FeatureAnnouncementTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class FeatureAnnouncementTest extends PHPUnit_Framework_TestCase
+class FeatureAnnouncementTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @var \Thruway\Connection

--- a/tests/WAMP/InvocationAndCallErrorTest.php
+++ b/tests/WAMP/InvocationAndCallErrorTest.php
@@ -6,7 +6,7 @@
  * Time: 11:46 PM
  */
 
-class InvocationAndCallErrorTest extends PHPUnit_Framework_TestCase {
+class InvocationAndCallErrorTest extends \PHPUnit\Framework\TestCase {
     private $_conn;
     private $_testResult;
     private $_error;

--- a/tests/WAMP/Issue100Test.php
+++ b/tests/WAMP/Issue100Test.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class Issue100Test extends PHPUnit_Framework_TestCase {
+class Issue100Test extends PHPUnit\Framework\TestCase {
     public function testUnsubscribeSendingUnsubThenError() {
         $broker = new \Thruway\Role\Broker();
 

--- a/tests/WAMP/NoChallengeTest.php
+++ b/tests/WAMP/NoChallengeTest.php
@@ -16,7 +16,7 @@ class AutoAuthProvider extends \Thruway\Authentication\AbstractAuthProviderClien
     }
 }
 
-class NoChallengeTest extends PHPUnit_Framework_TestCase
+class NoChallengeTest extends PHPUnit\Framework\TestCase
 {
     /*
      * This is a complex test - should do this a better way

--- a/tests/WAMP/PingTest.php
+++ b/tests/WAMP/PingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class PingTest extends \PHPUnit_Framework_TestCase {
+class PingTest extends \PHPUnit\Framework\TestCase {
     /**
      * @var \Thruway\Connection
      */

--- a/tests/WAMP/QueryParamAuthTest.php
+++ b/tests/WAMP/QueryParamAuthTest.php
@@ -3,7 +3,7 @@
 
 use Thruway\ClientSession;
 
-class QueryParamAuthTest extends PHPUnit_Framework_TestCase
+class QueryParamAuthTest extends \PHPUnit\Framework\TestCase
 {
 
     private $_error;

--- a/tests/WAMP/RawSocketTest.php
+++ b/tests/WAMP/RawSocketTest.php
@@ -5,7 +5,7 @@
  *
  *
  */
-class RawSocketTest extends PHPUnit_Framework_TestCase {
+class RawSocketTest extends PHPUnit\Framework\TestCase {
     private $_result;
 
     public function test() {

--- a/tests/WAMP/ReplaceOrphanedSessionTest.php
+++ b/tests/WAMP/ReplaceOrphanedSessionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReplaceOrphanedSessionTest extends PHPUnit_Framework_TestCase {
+class ReplaceOrphanedSessionTest extends \PHPUnit\Framework\TestCase {
     /**
      * @var \Thruway\Connection
      */

--- a/tests/WAMP/SessionMetaTest.php
+++ b/tests/WAMP/SessionMetaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SessionMetaTest extends PHPUnit_Framework_TestCase {
+class SessionMetaTest extends \PHPUnit\Framework\TestCase {
     protected $_conn;
     protected $_conn2;
     protected $_joinInfo;

--- a/tests/WAMP/WampCraTest.php
+++ b/tests/WAMP/WampCraTest.php
@@ -4,7 +4,7 @@
 use Thruway\ClientSession;
 use Thruway\Message\ChallengeMessage;
 
-class WampCraTest extends PHPUnit_Framework_TestCase
+class WampCraTest extends PHPUnit\Framework\TestCase
 {
 
     private $_error;

--- a/tests/WAMP/WampErrorExceptionTest.php
+++ b/tests/WAMP/WampErrorExceptionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class WampErrorExceptionTest extends PHPUnit_Framework_TestCase {
+class WampErrorExceptionTest extends PHPUnit\Framework\TestCase {
     function testWampErrorException() {
         $loop = \React\EventLoop\Factory::create();
 


### PR DESCRIPTION
This PR adds support for Symfony 5 and the new EventDispatcher, without breaking compatibility with `^2.7|^3.0|^4.0`.

This is a bit tricky because `Thruway\Event\Event` and `Thruway\Event\EventDispatcher` both extend/implement Symfony versions which are not consistent across all supported versions.

So my reasoning is:
- have `Thruway\Event\Event` and `Thruway\Event\EventDispatcher` behave exactly the same as their Symfony counterpart, no matter which Symfony version is used,
- internally, rely on a new `backwardsCompatibleDispatch()` method to make calls with the new parameter order and have them translated to the right calls to `dispatch()` for each Symfony version.

People using the lib can either continue to use `dispatch()`, which will behave like the one from the Symfony version they use, or use the `backwardsCompatibleDispatch()` which will behave like the newer version of `dispatch()`, even on older versions of Symfony, if they want to keep support for both older and newer versions of Symfony.

If they don't use Symfony, they can avoid a breaking change with their code by requiring `"symfony/event-dispatcher": "^4"`, or even `"symfony/event-dispatcher": "^3"` for older PHP versions.

I also added the 2 classes from `thruway/ratchet-transport` because unless I missed something, they can't work without `voryx/Thruway` and `voryx/Thruway` requires them too, so it's a bidirectional dependency.