### PR TITLE
Drop symfony/event-dispatcher dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/event-dispatcher": "^2.7|^3.0|^4.0",
         "voryx/thruway-common": "^1.0.5",
         "thruway/client": "^0.5.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4.3",

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -2,7 +2,56 @@
 
 namespace Thruway\Event;
 
-class Event extends \Symfony\Component\EventDispatcher\Event
+class Event
 {
+    /*
+     * Everything below taken from symfony/event-dispatcher at 3.4.41
+     *
+     * (c) Fabien Potencier <fabien@symfony.com>
+     *
+     * For the full copyright and license information, please view the LICENSE
+     * file that was distributed with this source code.
+     */
+    /*
+     * Event is the base class for classes containing event data.
+     *
+     * This class contains no event data. It is used by events that do not pass
+     * state information to an event handler when an event is raised.
+     *
+     * You can call the method stopPropagation() to abort the execution of
+     * further listeners in your event listener.
+     *
+     * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+     * @author Jonathan Wage <jonwage@gmail.com>
+     * @author Roman Borschel <roman@code-factory.org>
+     * @author Bernhard Schussek <bschussek@gmail.com>
+     */
+    /**
+     * @var bool Whether no further event listeners should be triggered
+     */
+    private $propagationStopped = false;
 
+    /**
+     * Returns whether further event listeners should be triggered.
+     *
+     * @see Event::stopPropagation()
+     *
+     * @return bool Whether propagation was already stopped for this event
+     */
+    public function isPropagationStopped()
+    {
+        return $this->propagationStopped;
+    }
+
+    /**
+     * Stops the propagation of the event to further event listeners.
+     *
+     * If multiple event listeners are connected to the same event, no
+     * further event listener will be triggered once any trigger calls
+     * stopPropagation().
+     */
+    public function stopPropagation()
+    {
+        $this->propagationStopped = true;
+    }
 }

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -4,13 +4,244 @@ namespace Thruway\Event;
 
 use Thruway\Module\RealmModuleInterface;
 
-class EventDispatcher extends \Symfony\Component\EventDispatcher\EventDispatcher implements EventDispatcherInterface
+class EventDispatcher implements EventDispatcherInterface
 {
     public function addRealmSubscriber(RealmModuleInterface $subscriber)
     {
         $events = $subscriber->getSubscribedRealmEvents();
         foreach ($events as $eventName => $event) {
             $this->addListener($eventName, [$subscriber, $event[0]], $event[1]);
+        }
+    }
+
+    /*
+     * Everything below taken from symfony/event-dispatcher at 3.4.41
+     *
+     * (c) Fabien Potencier <fabien@symfony.com>
+     *
+     * For the full copyright and license information, please view the LICENSE
+     * file that was distributed with this source code.
+     */
+    /*
+     * The EventDispatcherInterface is the central point of Symfony's event listener system.
+     *
+     * Listeners are registered on the manager and events are dispatched through the
+     * manager.
+     *
+     * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+     * @author Jonathan Wage <jonwage@gmail.com>
+     * @author Roman Borschel <roman@code-factory.org>
+     * @author Bernhard Schussek <bschussek@gmail.com>
+     * @author Fabien Potencier <fabien@symfony.com>
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     * @author Jordan Alliot <jordan.alliot@gmail.com>
+     * @author Nicolas Grekas <p@tchwork.com>
+     */
+    private $listeners = [];
+    private $sorted = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch($eventName, Event $event = null)
+    {
+        if (null === $event) {
+            $event = new Event();
+        }
+
+        if ($listeners = $this->getListeners($eventName)) {
+            $this->doDispatch($listeners, $eventName, $event);
+        }
+
+        return $event;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListeners($eventName = null)
+    {
+        if (null !== $eventName) {
+            if (empty($this->listeners[$eventName])) {
+                return [];
+            }
+
+            if (!isset($this->sorted[$eventName])) {
+                $this->sortListeners($eventName);
+            }
+
+            return $this->sorted[$eventName];
+        }
+
+        foreach ($this->listeners as $eventName => $eventListeners) {
+            if (!isset($this->sorted[$eventName])) {
+                $this->sortListeners($eventName);
+            }
+        }
+
+        return array_filter($this->sorted);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        if (empty($this->listeners[$eventName])) {
+            return null;
+        }
+
+        if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure) {
+            $listener[0] = $listener[0]();
+        }
+
+        foreach ($this->listeners[$eventName] as $priority => $listeners) {
+            foreach ($listeners as $k => $v) {
+                if ($v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure) {
+                    $v[0] = $v[0]();
+                    $this->listeners[$eventName][$priority][$k] = $v;
+                }
+                if ($v === $listener) {
+                    return $priority;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasListeners($eventName = null)
+    {
+        if (null !== $eventName) {
+            return !empty($this->listeners[$eventName]);
+        }
+
+        foreach ($this->listeners as $eventListeners) {
+            if ($eventListeners) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        $this->listeners[$eventName][$priority][] = $listener;
+        unset($this->sorted[$eventName]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeListener($eventName, $listener)
+    {
+        if (empty($this->listeners[$eventName])) {
+            return;
+        }
+
+        if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure) {
+            $listener[0] = $listener[0]();
+        }
+
+        foreach ($this->listeners[$eventName] as $priority => $listeners) {
+            foreach ($listeners as $k => $v) {
+                if ($v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure) {
+                    $v[0] = $v[0]();
+                }
+                if ($v === $listener) {
+                    unset($listeners[$k], $this->sorted[$eventName]);
+                } else {
+                    $listeners[$k] = $v;
+                }
+            }
+
+            if ($listeners) {
+                $this->listeners[$eventName][$priority] = $listeners;
+            } else {
+                unset($this->listeners[$eventName][$priority]);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
+            if (\is_string($params)) {
+                $this->addListener($eventName, [$subscriber, $params]);
+            } elseif (\is_string($params[0])) {
+                $this->addListener($eventName, [$subscriber, $params[0]], isset($params[1]) ? $params[1] : 0);
+            } else {
+                foreach ($params as $listener) {
+                    $this->addListener($eventName, [$subscriber, $listener[0]], isset($listener[1]) ? $listener[1] : 0);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
+            if (\is_array($params) && \is_array($params[0])) {
+                foreach ($params as $listener) {
+                    $this->removeListener($eventName, [$subscriber, $listener[0]]);
+                }
+            } else {
+                $this->removeListener($eventName, [$subscriber, \is_string($params) ? $params : $params[0]]);
+            }
+        }
+    }
+
+    /**
+     * Triggers the listeners of an event.
+     *
+     * This method can be overridden to add functionality that is executed
+     * for each listener.
+     *
+     * @param callable[] $listeners The event listeners
+     * @param string     $eventName The name of the event to dispatch
+     * @param Event      $event     The event object to pass to the event handlers/listeners
+     */
+    protected function doDispatch($listeners, $eventName, Event $event)
+    {
+        foreach ($listeners as $listener) {
+            if ($event->isPropagationStopped()) {
+                break;
+            }
+            \call_user_func($listener, $event, $eventName, $this);
+        }
+    }
+
+    /**
+     * Sorts the internal list of listeners for the given event by priority.
+     *
+     * @param string $eventName The name of the event
+     */
+    private function sortListeners($eventName)
+    {
+        krsort($this->listeners[$eventName]);
+        $this->sorted[$eventName] = [];
+
+        foreach ($this->listeners[$eventName] as $priority => $listeners) {
+            foreach ($listeners as $k => $listener) {
+                if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure) {
+                    $listener[0] = $listener[0]();
+                    $this->listeners[$eventName][$priority][$k] = $listener;
+                }
+                $this->sorted[$eventName][] = $listener;
+            }
         }
     }
 }

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -4,7 +4,93 @@ namespace Thruway\Event;
 
 use Thruway\Module\RealmModuleInterface;
 
-interface EventDispatcherInterface extends \Symfony\Component\EventDispatcher\EventDispatcherInterface
+interface EventDispatcherInterface
 {
     public function addRealmSubscriber(RealmModuleInterface $subscriber);
+
+    /*
+     * Everything below taken from symfony/event-dispatcher at 3.4.41
+     *
+     * (c) Fabien Potencier <fabien@symfony.com>
+     *
+     * For the full copyright and license information, please view the LICENSE
+     * file that was distributed with this source code.
+     */
+    /*
+     * The EventDispatcherInterface is the central point of Symfony's event listener system.
+     * Listeners are registered on the manager and events are dispatched through the
+     * manager.
+     *
+     * @author Bernhard Schussek <bschussek@gmail.com>
+     */
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param string     $eventName The name of the event to dispatch. The name of
+     *                              the event is the name of the method that is
+     *                              invoked on listeners.
+     * @param Event|null $event     The event to pass to the event handlers/listeners
+     *                              If not supplied, an empty Event instance is created
+     *
+     * @return Event
+     */
+    public function dispatch($eventName, Event $event = null);
+
+    /**
+     * Adds an event listener that listens on the specified events.
+     *
+     * @param string   $eventName The event to listen on
+     * @param callable $listener  The listener
+     * @param int      $priority  The higher this value, the earlier an event
+     *                            listener will be triggered in the chain (defaults to 0)
+     */
+    public function addListener($eventName, $listener, $priority = 0);
+
+    /**
+     * Adds an event subscriber.
+     *
+     * The subscriber is asked for all the events it is
+     * interested in and added as a listener for these events.
+     */
+    public function addSubscriber(EventSubscriberInterface $subscriber);
+
+    /**
+     * Removes an event listener from the specified events.
+     *
+     * @param string   $eventName The event to remove a listener from
+     * @param callable $listener  The listener to remove
+     */
+    public function removeListener($eventName, $listener);
+
+    public function removeSubscriber(EventSubscriberInterface $subscriber);
+
+    /**
+     * Gets the listeners of a specific event or all listeners sorted by descending priority.
+     *
+     * @param string|null $eventName The name of the event
+     *
+     * @return array The event listeners for the specified event, or all event listeners by event name
+     */
+    public function getListeners($eventName = null);
+
+    /**
+     * Gets the listener priority for a specific event.
+     *
+     * Returns null if the event or the listener does not exist.
+     *
+     * @param string   $eventName The name of the event
+     * @param callable $listener  The listener
+     *
+     * @return int|null The event listener priority
+     */
+    public function getListenerPriority($eventName, $listener);
+
+    /**
+     * Checks whether an event has any registered listeners.
+     *
+     * @param string|null $eventName The name of the event
+     *
+     * @return bool true if the specified event has any listeners, false otherwise
+     */
+    public function hasListeners($eventName = null);
 }

--- a/src/Event/EventSubscriberInterface.php
+++ b/src/Event/EventSubscriberInterface.php
@@ -2,7 +2,47 @@
 
 namespace Thruway\Event;
 
-interface EventSubscriberInterface extends \Symfony\Component\EventDispatcher\EventSubscriberInterface
+/*
+ * Everything below taken from symfony/event-dispatcher at 3.4.41
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+/**
+ * An EventSubscriber knows itself what events it is interested in.
+ * If an EventSubscriber is added to an EventDispatcherInterface, the manager invokes
+ * {@link getSubscribedEvents} and registers the subscriber as a listener for all
+ * returned events.
+ *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+interface EventSubscriberInterface
 {
-
-} 
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * The array keys are event names and the value can be:
+     *
+     *  * The method name to call (priority defaults to 0)
+     *  * An array composed of the method name to call and the priority
+     *  * An array of arrays composed of the method names to call and respective
+     *    priorities, or 0 if unset
+     *
+     * For instance:
+     *
+     *  * ['eventName' => 'methodName']
+     *  * ['eventName' => ['methodName', $priority]]
+     *  * ['eventName' => [['methodName1', $priority], ['methodName2']]]
+     *
+     * The code must not depend on runtime state as it will only be called at compile time.
+     * All logic depending on runtime state must be put into the individual methods handling the events.
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents();
+}

--- a/src/Event/SYMFONY-LICENSE
+++ b/src/Event/SYMFONY-LICENSE
@@ -1,0 +1,23 @@
+Portions of the Event*.php files are taken from symfony/event-dispatcher
+This is the LICENSE file from that package that covers that code.
+------------------------------------------------
+
+Copyright (c) 2004-2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Drop dependency on `symfony/event-dispatcher`.

This pulls the needed code from `symfony/event-dispatcher` into the project allowing us to drop the dependency on the symfony package so we don't have to keep making changes to keep up.

Some may consider this a BC break as the events no longer extend the symfony events. As such this will likely be tagged as 0.6.0 once merged.

Replaces #342
Replaces #331 
Replaces #329 
Fixes #328
