### PR TITLE
Update SubscriptionGroup.php

### DIFF
--- a/src/Subscription/SubscriptionGroup.php
+++ b/src/Subscription/SubscriptionGroup.php
@@ -120,7 +120,7 @@ class SubscriptionGroup
             $authid    = $authenticationDetails->getAuthId();
         }
 
-        if ((!$msg->excludeMe() || $subscription->getSession() != $session)
+        if ((!$msg->excludeMe() || $sessionId!= $session->getSessionId())
             && !$msg->isExcluded($sessionId)
             && $msg->isWhiteListed($sessionId)
             && $msg->hasEligibleAuthrole($authroles)


### PR DESCRIPTION
Fix issue related to compare two objects:
PHP Fatal error:  Nesting level too deep - recursive dependency? in /opt/application/backend/vendor/voryx/thruway/src/Subscription/SubscriptionGroup.php on line 123

As Example:
https://www.richardlord.net/blog/php/php-nesting-level-too-deep-recursive-dependency.html

Here is official PHP doc: https://www.php.net/manual/en/language.oop5.object-comparison.php