### PR TITLE
Removed a requirement for role of authorization rules to be a valid URI.

### DIFF
--- a/src/Authentication/AuthorizationManager.php
+++ b/src/Authentication/AuthorizationManager.php
@@ -271,7 +271,7 @@ class AuthorizationManager extends RouterModuleClient implements RealmModuleInte
             isset($rule->allow)
         ) {
             if ($this->isValidAction($rule->action) &&
-                static::isValidRuleUri($rule->uri) && Utils::uriIsValid($rule->role)
+                static::isValidRuleUri($rule->uri)
             ) {
                 if ($rule->allow === true || $rule->allow === false) {
                     return (object)[


### PR DESCRIPTION
There is nothing in the WAMP spec that says an auth role must be a valid URI.

No other part of Thruway assumes the role to be a valid URI.

I would add/fix the unit tests too to make sure this is checked, but honestly, I'm bit lost on the tests organization.