### PR TITLE
Subscription meta events

### DIFF
--- a/src/Role/Broker.php
+++ b/src/Role/Broker.php
@@ -273,6 +273,11 @@ class Broker implements RealmModuleInterface
         }
     }
 
+  /**
+   * Called when a session unsubscribe or leave the group.
+   * Will clean and remove the group if this was the last subscription to it
+   * @param $key
+   */
     private function cleanSubscriptionGroup($key)
     {
       $subscriptions = $this->subscriptionGroups[$key]->getSubscriptions();

--- a/src/Subscription/SubscriptionGroup.php
+++ b/src/Subscription/SubscriptionGroup.php
@@ -72,6 +72,7 @@ class SubscriptionGroup
     }
 
     /**
+     * Is subscription group already a meta event?
      * @return bool
      */
     public function isMetaSubscription()
@@ -80,6 +81,7 @@ class SubscriptionGroup
     }
 
     /**
+     * Publish a meta event ONLY if not already a meta subscription group
      * @param string $metaEvent
      * @param Subscription $subscription
      */

--- a/src/Subscription/SubscriptionGroup.php
+++ b/src/Subscription/SubscriptionGroup.php
@@ -34,6 +34,11 @@ class SubscriptionGroup
     private $id;
 
     /**
+     * @var \DateTime
+     */
+    private $created;
+
+    /**
      * @var array
      */
     private $subscriptions = [];
@@ -69,6 +74,8 @@ class SubscriptionGroup
         $this->setUri($uri);
         $this->setMatcher($matcher);
         $this->lastPublicationId = 0;
+        $this->id = Utils::getUniqueId();
+        $this->created = new \DateTime();
     }
 
     /**
@@ -364,6 +371,8 @@ class SubscriptionGroup
     private function getMetaInfo()
     {
       return [
+        'id'         => $this->id,
+        'created'    => $this->created->format(\DateTime::ATOM),
         'uri'        => $this->uri,
         'match'      => $this->getMatchType(),
       ];


### PR DESCRIPTION
Following my question at https://github.com/voryx/Thruway/issues/361 

Added some meta events to the router, from the **Subscription Meta API**.

Refs:
https://wamp-proto.org/_static/gen/wamp_latest.html#subscription-meta-events
https://crossbar.io/docs/Subscription-Meta-Events-and-Procedures/?highlight=meta#events

Did not add the `subscription_meta_api` to the broker as this is only a partial implementation of the whole API.   It does not include the api Procedures.

Might implement the procedures in a near future.


Usage
```
$session->subscribe("wamp.metaevent.subscription.on_subscribe", $callbackFn);
$session->subscribe("wamp.metaevent.subscription.on_unsubscribe", $callbackFn);
$session->subscribe("wamp.metaevent.subscription.on_create", $callbackFn);
$session->subscribe("wamp.metaevent.subscription.on_delete", $callbackFn);
```

$callbackFn will receive $args as first argument
where
$args[0] = session meta information (the session that triggered the event)
$args[1] = subscription meta information [ uri: string, match: string ]